### PR TITLE
[KOGITO-4453] Fix overwriting propertiesConfigMap

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,5 +9,6 @@
 - [KOGITO-4521](https://issues.redhat.com/browse/KOGITO-4521) - `process-quarkus-example` does not start correctly on Openshift with `persistence,events` profile
 - [KOGITO-4477](https://issues.redhat.com/browse/KOGITO-4477) - Operator sees the Infinispan as not ready after it is restarted
 - [KOGITO-4644](https://issues.redhat.com/browse/KOGITO-4644) - Operator Binary build & BDD tests should handle correctly fast jars
+- [KOGITO-4453](https://issues.redhat.com/browse/KOGITO-4453) - Operator overwrites user's configmap provided with propertiesConfigMap
 
 ## Known Issues

--- a/core/test/kogitosupportingservice.go
+++ b/core/test/kogitosupportingservice.go
@@ -30,6 +30,24 @@ func CreateFakeJobsService(namespace string) *v1beta1.KogitoSupportingService {
 	return createFakeKogitoSupportingServiceInstance("jobs-service", namespace, api.JobsService)
 }
 
+// CreateFakeJobsServiceWithPropertiesConfigMap ...
+func CreateFakeJobsServiceWithPropertiesConfigMap(namespace string, propertiesConfigMapName string) *v1beta1.KogitoSupportingService {
+	replicas := int32(1)
+	return &v1beta1.KogitoSupportingService{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "jobs-service",
+			Namespace: namespace,
+		},
+		Spec: v1beta1.KogitoSupportingServiceSpec{
+			ServiceType: api.JobsService,
+			KogitoServiceSpec: v1beta1.KogitoServiceSpec{
+				Replicas:            &replicas,
+				PropertiesConfigMap: propertiesConfigMapName,
+			},
+		},
+	}
+}
+
 // CreateFakeMgmtConsole ...
 func CreateFakeMgmtConsole(namespace string) *v1beta1.KogitoSupportingService {
 	return createFakeKogitoSupportingServiceInstance("mgmt-console", namespace, api.MgmtConsole)


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-4453

## Cause of Bug
The cause of this bug is that the `application.properties` provided in the propertiesConfigMap was not being added to the `appProps` map in `createRequiredResources()`. So when the ConfigMap is created in `createRequiredResources()`, it would not have any of the `application.properties` provided and delete the entire propertiesConfigMap when comparing the deltas of what is created and deployed in the deploy loop.

## Fix
I fixed this bug by adding the `application.properties` from the propertiesConfigMap to the `appProps` map in `createRequiredResources()`.  This has to be done outside of the `if` block that checks if there is a resolvable image or deployment because I came across the case when there wasn't a resolvable image/deployment ready. In this case, the `application.properties` would not be added to the `appProps` map, and the bug would occur again.

## Testing
I tested my code with a propertiesConfigMap added to a KogitoRuntime/KogitoSupportingService:
```yaml
apiVersion: app.kiegroup.org/v1beta1
kind: KogitoRuntime
metadata:
  name: qe
spec:
  replicas: 1
  image: quay.io/kmok/process-quarkus-example
  propertiesConfigMap: qe-cm
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: qe-cm
data:
  application.properties: |
    kafka.sals.mechanism=PLAIN
    kafka.security.protocol=SASL_SSL
```

```yaml
apiVersion: app.kiegroup.org/v1beta1
kind: KogitoRuntime
metadata:
  name: tq
spec:
  replicas: 1
  image: quay.io/kmok/process-timer-quarkus
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: js-cm
data:
  application.properties: |
    kafka.sals.mechanism=PLAIN
    kafka.security.protocol=SASL_SSL
---
apiVersion: app.kiegroup.org/v1beta1
kind: KogitoSupportingService
metadata:
  name: jobs-service
spec:
  serviceType: JobsService
  replicas: 1
  propertiesConfigMap: js-cm
```

I also added a unit test to check if the propertiesConfigMap shows up in the created resources even if there if no resolvable image yet.

## Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: 
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change
