### PR TITLE
KOGITO-3344 - Failover scenario for scaling Kafka to 0 using BDD tests

### DIFF
--- a/test/framework/graphql.go
+++ b/test/framework/graphql.go
@@ -42,9 +42,13 @@ func WaitForSuccessfulGraphQLRequest(namespace, uri, path, query string, timeout
 func WaitForSuccessfulGraphQLRequestUsingPagination(namespace, uri, path, query string, timeoutInMin, pageSize, totalSize int, response interface{}, afterEachResponse func(response interface{}) (bool, error), afterFullRequest func() (bool, error)) error {
 	return WaitForOnOpenshift(namespace, fmt.Sprintf("GraphQL query %s on path '%s' using '%s' access token to be successful", query, path, graphQLNoAuthToken), timeoutInMin,
 		func() (bool, error) {
+			totalPages := totalSize / pageSize
+			if totalSize%pageSize != 0 {
+				totalPages++
+			}
 			for queried := 0; queried < totalSize; {
 				query := strings.ReplaceAll(query, "$offset", strconv.Itoa(queried))
-				GetLogger(namespace).Info("Querying", "page no.", queried/pageSize+1, "of", totalSize/pageSize, "query", query)
+				GetLogger(namespace).Info("Querying", "page no.", queried/pageSize+1, "of", totalPages, "query", query)
 				err := ExecuteGraphQLRequestWithLoggingOption(namespace, uri, path, query, graphQLNoAuthToken, response, false)
 				if err != nil {
 					return false, err

--- a/test/framework/kafka.go
+++ b/test/framework/kafka.go
@@ -56,3 +56,19 @@ func DeployKafkaTopic(namespace, kafkaTopicName, kafkaInstanceName string) error
 
 	return nil
 }
+
+// ScaleKafkaInstanceDown scales a Kafka instance down by killing its pod temporarily
+func ScaleKafkaInstanceDown(namespace, kafkaInstanceName string) error {
+	GetLogger(namespace).Info("Scaling Kafka Instance down", "instance name", kafkaInstanceName)
+	pods, err := GetPodsWithLabels(namespace, map[string]string{"strimzi.io/name": kafkaInstanceName + "-kafka"})
+	if err != nil {
+		return err
+	} else if len(pods.Items) != 1 {
+		return fmt.Errorf("Kafka instance should have just one kafka pod running")
+	}
+	if err = DeleteObject(&pods.Items[0]); err != nil {
+		return fmt.Errorf("Error scaling Kafka instance down by deleting a kafka pod. The nested error is: %v", err)
+	}
+
+	return nil
+}

--- a/test/steps/kafka.go
+++ b/test/steps/kafka.go
@@ -26,7 +26,9 @@ import (
 func registerKafkaSteps(ctx *godog.ScenarioContext, data *Data) {
 	ctx.Step(`^Kafka Operator is deployed$`, data.kafkaOperatorIsDeployed)
 	ctx.Step(`^Kafka instance "([^"]*)" has (\d+) (?:pod|pods) running within (\d+) (?:minute|minutes)$`, data.kafkaInstanceHasPodsRunningWithinMinutes)
+	ctx.Step(`^Kafka instance "([^"]*)" has (\d+) kafka (?:pod|pods) running within (\d+) (?:minute|minutes)$`, data.kafkaInstanceHasKafkaPodsRunningWithinMinutes)
 	ctx.Step(`^Kafka instance "([^"]*)" is deployed$`, data.kafkaInstanceIsDeployed)
+	ctx.Step(`^Scale Kafka instance "([^"]*)" down`, data.scaleKafkaInstanceDown)
 	ctx.Step(`^Kafka topic "([^"]*)" is deployed$`, data.kafkaTopicIsDeployed)
 }
 
@@ -38,6 +40,10 @@ func (data *Data) kafkaInstanceHasPodsRunningWithinMinutes(name string, numberOf
 	return framework.WaitForPodsWithLabel(data.Namespace, "strimzi.io/name", name+"-entity-operator", numberOfPods, timeOutInMin)
 }
 
+func (data *Data) kafkaInstanceHasKafkaPodsRunningWithinMinutes(name string, numberOfPods, timeOutInMin int) error {
+	return framework.WaitForPodsWithLabel(data.Namespace, "strimzi.io/name", name+"-kafka", numberOfPods, timeOutInMin)
+}
+
 func (data *Data) kafkaInstanceIsDeployed(name string) error {
 	kafka := getKafkaDefaultResource(name, data.Namespace)
 
@@ -46,6 +52,10 @@ func (data *Data) kafkaInstanceIsDeployed(name string) error {
 	}
 
 	return framework.WaitForPodsWithLabel(data.Namespace, "strimzi.io/name", name+"-entity-operator", 1, 5)
+}
+
+func (data *Data) scaleKafkaInstanceDown(name string) error {
+	return framework.ScaleKafkaInstanceDown(data.Namespace, name)
 }
 
 func (data *Data) kafkaTopicIsDeployed(name string) error {


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart: :cake:! 

[KOGITO-3344](https://issues.redhat.com/browse/KOGITO-3344)

* There is currently no other way to scale Kafka to 0 other than killing a pod. Kafka CR doesn't accept values less than 1 for number of instances.
* Even though it's just a deletion of a specific pod, I added a separate method for scaling Kafka to 0 directly to the framework, so we have this functionality right there in case the framework is extracted to a separate repo in the future.

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change