### PR TITLE
[KOGITO-3105] - Missing status for failures for KogitoRuntime CRs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,5 +12,5 @@
 - [KOGITO-4453](https://issues.redhat.com/browse/KOGITO-4453) - Operator overwrites user's configmap provided with propertiesConfigMap
 - [KOGITO-4469](https://issues.redhat.com/browse/KOGITO-4469) - Conditions should reflect latest evaluated status
 - [KOGITO-4753](https://issues.redhat.com/browse/KOGITO-4753) - Cannot deploy Kogito operator together with RHPAM Kogito operator
-
+- [KOGITO-3105](https://issues.redhat.com/browse/KOGITO-3105) - Missing status for failures for KogitoRuntime CRs
 ## Known Issues

--- a/api/kogitoservices_types.go
+++ b/api/kogitoservices_types.go
@@ -61,6 +61,8 @@ const (
 	UnknownProvisioningReason KogitoServiceConditionReason = "UnrecoverableError"
 	// FinishedProvisioningReason ...
 	FinishedProvisioningReason KogitoServiceConditionReason = "RequestedReplicasEqualToAvailableReplicas"
+	// ImageStreamNotReadyReason - Unable to deploy Kogito Infra
+	ImageStreamNotReadyReason KogitoServiceConditionReason = "ImageStreamNotReadyReason"
 )
 
 // KogitoService defines the interface for any Kogito service that the operator can handle, e.g. Data Index, Jobs Service, Runtimes, etc.

--- a/controllers/kogitoruntime_controller_test.go
+++ b/controllers/kogitoruntime_controller_test.go
@@ -27,8 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	meta2 "k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"testing"
 )
 
@@ -192,11 +190,9 @@ func TestReconcileKogitoRuntime_InvalidCustomImage(t *testing.T) {
 		},
 	}
 	cli := test.NewFakeClientBuilder().AddK8sObjects(instance, imageStream).OnOpenShift().Build()
-	r := &KogitoRuntimeReconciler{Client: cli, Scheme: meta.GetRegisteredSchema(), Log: test.TestLogger}
-	_, err := r.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}})
-	assert.Error(t, err)
+	test.AssertReconcileMustRequeue(t, &KogitoRuntimeReconciler{Client: cli, Scheme: meta.GetRegisteredSchema(), Log: test.TestLogger}, instance)
 
-	_, err = kubernetes.ResourceC(cli).Fetch(instance)
+	_, err := kubernetes.ResourceC(cli).Fetch(instance)
 	assert.NoError(t, err)
 	assert.NotNil(t, instance.Status)
 	assert.Len(t, *instance.Status.Conditions, 3)

--- a/core/infrastructure/image.go
+++ b/core/infrastructure/image.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/version"
 	imgv1 "github.com/openshift/api/image/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"strings"
 )
@@ -102,6 +103,9 @@ func (i *imageHandler) CreateImageStreamIfNotExists() (*imgv1.ImageStream, error
 // Can be empty if on OpenShift and the ImageStream is not ready.
 func (i *imageHandler) ResolveImage() (string, error) {
 	if i.Client.IsOpenshift() {
+		if err := i.validateImageStreamTagStatus(); err != nil {
+			return "", err
+		}
 		// the image is on an ImageStreamTag object
 		ist, err := openshift.ImageStreamC(i.Client).FetchTag(types.NamespacedName{Name: i.imageStreamName, Namespace: i.namespace}, i.resolveTag())
 		if err != nil {
@@ -112,6 +116,40 @@ func (i *imageHandler) ResolveImage() (string, error) {
 		return ist.Image.DockerImageReference, nil
 	}
 	return i.resolveRegistryImage(), nil
+}
+
+func (i *imageHandler) validateImageStreamTagStatus() error {
+	imageStreamHandler := NewImageStreamHandler(i.Context)
+	is, err := imageStreamHandler.FetchImageStream(types.NamespacedName{Name: i.imageStreamName, Namespace: i.namespace})
+	if err != nil {
+		return err
+	}
+	if is == nil {
+		return nil
+	}
+	tagCondition := i.findTagStatusCondition(is)
+	if tagCondition == nil {
+		return nil
+	}
+	if tagCondition.Status == corev1.ConditionFalse {
+		return fmt.Errorf(tagCondition.Message)
+	}
+	return nil
+}
+
+// findTagStatusCondition finds the ImportSuccess conditionType in conditions.
+func (i *imageHandler) findTagStatusCondition(is *imgv1.ImageStream) *imgv1.TagEventCondition {
+	tagEvents := is.Status.Tags
+	for _, tagEvent := range tagEvents {
+		if tagEvent.Tag == i.resolveTag() {
+			for _, condition := range tagEvent.Conditions {
+				if condition.Type == imgv1.ImportSuccess {
+					return &condition
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // resolveRegistryImage resolves images like "quay.io/kiegroup/kogito-jobs-service:latest", as informed by user.

--- a/core/kogitoservice/deployer_resources.go
+++ b/core/kogitoservice/deployer_resources.go
@@ -180,7 +180,7 @@ func (s *serviceDeployer) setOwner(resources map[reflect.Type][]resource.Kuberne
 func (s *serviceDeployer) getKogitoServiceImage(imageHandler infrastructure.ImageHandler, instance api.KogitoService) (string, error) {
 	image, err := imageHandler.ResolveImage()
 	if err != nil {
-		return "", err
+		return "", errorForImageStreamNotReady(err)
 	}
 	if len(image) > 0 {
 		return image, nil

--- a/core/kogitoservice/errors.go
+++ b/core/kogitoservice/errors.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	reconciliationIntervalAfterImageStreamError          = time.Minute
 	reconciliationIntervalAfterInfraError                = time.Minute
 	reconciliationIntervalAfterMessagingError            = time.Second * 30
 	reconciliationIntervalMonitoringEndpointNotAvailable = time.Second * 10
@@ -50,6 +51,14 @@ func errorForInfraNotReady(service api.KogitoService, infraName string, conditio
 		reason:                 api.KogitoInfraNotReadyReason,
 		innerError: fmt.Errorf("KogitoService '%s' is waiting for infra dependency; skipping deployment; KogitoInfra not ready: %s; Status: %s",
 			service.GetName(), infraName, conditionReason),
+	}
+}
+
+func errorForImageStreamNotReady(err error) reconciliationError {
+	return reconciliationError{
+		reconciliationInterval: reconciliationIntervalAfterImageStreamError,
+		reason:                 api.ImageStreamNotReadyReason,
+		innerError:             err,
 	}
 }
 


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Jira : https://issues.redhat.com/browse/KOGITO-3105
With this fix, conditions will looks as following :
```
Status:
  Cloud Events:
  Conditions:
    Last Transition Time:  2021-03-25T09:19:17Z
    Message:               you may not have access to the container image "quay.io/kiegroup/process-quarkus-example-1:latest"
    Reason:                ReconciliationFailure
    Status:                True
    Type:                  Failed
    Last Transition Time:  2021-03-25T09:19:17Z
    Message:               
    Reason:                RequestedReplicasNotEqualToAvailableReplicas
    Status:                False
    Type:                  Provisioning
    Last Transition Time:  2021-03-25T09:19:17Z
    Message:               
    Reason:                NoPodAvailable
    Status:                False
    Type:                  Deployed

```

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change