### PR TITLE
[KOGITO-4781] Fix deployment constantly updating

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,5 +12,6 @@
 - [KOGITO-4729](https://issues.redhat.com/browse/KOGITO-4729) - Upgrade from Operator 1.3.0 to 1.4.0 fails with reference to Kafka Topics
 - [KOGITO-4905](https://issues.redhat.com/browse/KOGITO-4905) - COPY line in springboot.Dockerfile doesn't work
 - [KOGITO-4894](https://issues.redhat.com/browse/KOGITO-4894) - Remove `image` default value in KogitoRuntime CR (problem in OCP console)
+- [KOGITO-4781](https://issues.redhat.com/browse/KOGITO-4781) - Deployment constantly updates when deployed with custom probes
 
 ## Known Issues

--- a/core/kogitoservice/probe_test.go
+++ b/core/kogitoservice/probe_test.go
@@ -24,6 +24,10 @@ import (
 	"testing"
 )
 
+const (
+	customProbePort = 9000
+)
+
 func TestGetProbeForKogitoService_DefaultConfiguration(t *testing.T) {
 	serviceDefinition := ServiceDefinition{
 		HealthCheckProbe: QuarkusHealthCheckProbe,
@@ -36,27 +40,51 @@ func TestGetProbeForKogitoService_DefaultConfiguration(t *testing.T) {
 	assert.Equal(t, quarkusProbeReadinessPath, readinessProbe.Handler.HTTPGet.Path)
 	assert.Equal(t, intstr.IntOrString{IntVal: int32(framework.DefaultExposedPort)}, readinessProbe.Handler.HTTPGet.Port)
 	assert.Equal(t, corev1.URISchemeHTTP, readinessProbe.Handler.HTTPGet.Scheme)
+	assert.Equal(t, int32(1), readinessProbe.TimeoutSeconds)
+	assert.Equal(t, int32(10), readinessProbe.PeriodSeconds)
+	assert.Equal(t, int32(1), readinessProbe.SuccessThreshold)
+	assert.Equal(t, int32(3), readinessProbe.FailureThreshold)
 
 	assert.Equal(t, quarkusProbeLivenessPath, livenessProbe.Handler.HTTPGet.Path)
 	assert.Equal(t, intstr.IntOrString{IntVal: int32(framework.DefaultExposedPort)}, livenessProbe.Handler.HTTPGet.Port)
 	assert.Equal(t, corev1.URISchemeHTTP, livenessProbe.Handler.HTTPGet.Scheme)
+	assert.Equal(t, int32(1), livenessProbe.TimeoutSeconds)
+	assert.Equal(t, int32(10), livenessProbe.PeriodSeconds)
+	assert.Equal(t, int32(1), livenessProbe.SuccessThreshold)
+	assert.Equal(t, int32(3), livenessProbe.FailureThreshold)
 }
 
 func TestGetProbeForKogitoService_CustomConfiguration(t *testing.T) {
 	serviceDefinition := ServiceDefinition{
 		HealthCheckProbe: QuarkusHealthCheckProbe,
 	}
+	customLivenessProbePath := "/live"
+	customReadinessProbePath := "/ready"
 
 	service := test.CreateFakeKogitoRuntime(t.Name())
 	service.GetSpec().SetProbes(&v1beta1.KogitoProbe{
 		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   customLivenessProbePath,
+					Port:   intstr.IntOrString{IntVal: customProbePort},
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
 			InitialDelaySeconds: 100,
 			TimeoutSeconds:      10,
 			PeriodSeconds:       5,
-			SuccessThreshold:    2,
+			SuccessThreshold:    1,
 			FailureThreshold:    5,
 		},
 		ReadinessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   customReadinessProbePath,
+					Port:   intstr.IntOrString{IntVal: customProbePort},
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
 			InitialDelaySeconds: 200,
 			TimeoutSeconds:      20,
 			PeriodSeconds:       25,
@@ -68,15 +96,66 @@ func TestGetProbeForKogitoService_CustomConfiguration(t *testing.T) {
 	livenessProbe := healthCheckProbe.liveness
 	readinessProbe := healthCheckProbe.readiness
 
+	assert.Equal(t, customLivenessProbePath, livenessProbe.Handler.HTTPGet.Path)
+	assert.Equal(t, intstr.IntOrString{IntVal: customProbePort}, livenessProbe.Handler.HTTPGet.Port)
+	assert.Equal(t, corev1.URISchemeHTTPS, livenessProbe.Handler.HTTPGet.Scheme)
 	assert.Equal(t, int32(100), livenessProbe.InitialDelaySeconds)
 	assert.Equal(t, int32(10), livenessProbe.TimeoutSeconds)
 	assert.Equal(t, int32(5), livenessProbe.PeriodSeconds)
-	assert.Equal(t, int32(2), livenessProbe.SuccessThreshold)
+	assert.Equal(t, int32(1), livenessProbe.SuccessThreshold)
 	assert.Equal(t, int32(5), livenessProbe.FailureThreshold)
 
+	assert.Equal(t, customReadinessProbePath, readinessProbe.Handler.HTTPGet.Path)
+	assert.Equal(t, intstr.IntOrString{IntVal: customProbePort}, readinessProbe.Handler.HTTPGet.Port)
+	assert.Equal(t, corev1.URISchemeHTTPS, readinessProbe.Handler.HTTPGet.Scheme)
 	assert.Equal(t, int32(200), readinessProbe.InitialDelaySeconds)
 	assert.Equal(t, int32(20), readinessProbe.TimeoutSeconds)
 	assert.Equal(t, int32(25), readinessProbe.PeriodSeconds)
 	assert.Equal(t, int32(22), readinessProbe.SuccessThreshold)
 	assert.Equal(t, int32(25), readinessProbe.FailureThreshold)
+}
+
+func TestGetProbeForKogitoService_CustomConfigurationWithoutDefaultFields(t *testing.T) {
+	serviceDefinition := ServiceDefinition{
+		HealthCheckProbe: QuarkusHealthCheckProbe,
+	}
+
+	service := test.CreateFakeKogitoRuntime(t.Name())
+	service.GetSpec().SetProbes(&v1beta1.KogitoProbe{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.IntOrString{IntVal: customProbePort},
+				},
+			},
+		},
+		ReadinessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.IntOrString{IntVal: customProbePort},
+				},
+			},
+		},
+	})
+	healthCheckProbe := getProbeForKogitoService(serviceDefinition, service)
+	livenessProbe := healthCheckProbe.liveness
+	readinessProbe := healthCheckProbe.readiness
+
+	assert.Equal(t, quarkusProbeLivenessPath, livenessProbe.Handler.HTTPGet.Path)
+	assert.Equal(t, intstr.IntOrString{IntVal: customProbePort}, livenessProbe.Handler.HTTPGet.Port)
+	assert.Equal(t, corev1.URISchemeHTTP, livenessProbe.Handler.HTTPGet.Scheme)
+	assert.Equal(t, int32(0), livenessProbe.InitialDelaySeconds)
+	assert.Equal(t, int32(1), livenessProbe.TimeoutSeconds)
+	assert.Equal(t, int32(10), livenessProbe.PeriodSeconds)
+	assert.Equal(t, int32(1), livenessProbe.SuccessThreshold)
+	assert.Equal(t, int32(3), livenessProbe.FailureThreshold)
+
+	assert.Equal(t, quarkusProbeReadinessPath, readinessProbe.Handler.HTTPGet.Path)
+	assert.Equal(t, intstr.IntOrString{IntVal: customProbePort}, readinessProbe.Handler.HTTPGet.Port)
+	assert.Equal(t, corev1.URISchemeHTTP, readinessProbe.Handler.HTTPGet.Scheme)
+	assert.Equal(t, int32(0), readinessProbe.InitialDelaySeconds)
+	assert.Equal(t, int32(1), readinessProbe.TimeoutSeconds)
+	assert.Equal(t, int32(10), readinessProbe.PeriodSeconds)
+	assert.Equal(t, int32(1), readinessProbe.SuccessThreshold)
+	assert.Equal(t, int32(3), readinessProbe.FailureThreshold)
 }


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-4781

## Description
This PR sets default values for probes so that values not specified for probes in the YAML have the default values in the requested resources. This makes it so that it matches the deployed resources (Kubernetes was automatically adding the default values for unspecified fields) and prevents the operator from continually updating the deployment when it sees a discrepancy between the requested and deployed resources.

## Testing
I updated the probe unit tests to check that the default values are being added when they are not specified. I also deployed the following YAML on both `master` and this branch:
```yaml
apiVersion: app.kiegroup.org/v1beta1
kind: KogitoRuntime
metadata:
  name: qe
spec:
  replicas: 1
  image: quay.io/kmok/process-quarkus-example
  probes:
    livenessProbe:
      httpGet:
        path: /q/health/live
        port: 8080
```
Where the operator would continually run in `master` to update the deployment but not in my branch.

## Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: 
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change
