### PR TITLE
[KOGITO-4898] Set probe defaults based on YAML action values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,4 +3,6 @@
 
 ## Bug Fixes
 - [KOGITO-5005](https://issues.redhat.com/browse/KOGITO-5005) - Operator print irrelevant metadata in logs
+- [KOGITO-4898](https://issues.redhat.com/browse/KOGITO-4898) - Probe defaults should be based on YAML action values
+
 ## Known Issues

--- a/controllers/kogitoruntime_controller.go
+++ b/controllers/kogitoruntime_controller.go
@@ -15,7 +15,6 @@
 package controllers
 
 import (
-	"github.com/kiegroup/kogito-operator/api"
 	"github.com/kiegroup/kogito-operator/api/v1beta1"
 	"github.com/kiegroup/kogito-operator/core/client"
 	"github.com/kiegroup/kogito-operator/core/connector"
@@ -93,10 +92,6 @@ func (r *KogitoRuntimeReconciler) Reconcile(req ctrl.Request) (result ctrl.Resul
 		return
 	}
 
-	healthCheckProbeType := kogitoservice.TCPHealthCheckProbe
-	if instance.GetSpec().GetRuntime() == api.QuarkusRuntimeType {
-		healthCheckProbeType = kogitoservice.QuarkusHealthCheckProbe
-	}
 	deploymentHandler := NewRuntimeDeployerHandler(context, instance, supportingServiceHandler, runtimeHandler)
 	definition := kogitoservice.ServiceDefinition{
 		Request:            req,
@@ -106,7 +101,6 @@ func (r *KogitoRuntimeReconciler) Reconcile(req ctrl.Request) (result ctrl.Resul
 		OnObjectsCreate:    deploymentHandler.OnObjectsCreate,
 		OnGetComparators:   deploymentHandler.OnGetComparators,
 		CustomService:      true,
-		HealthCheckProbe:   healthCheckProbeType,
 	}
 	infraHandler := internal.NewKogitoInfraHandler(context)
 	requeueAfter, err := kogitoservice.NewServiceDeployer(context, definition, instance, infraHandler).Deploy()

--- a/core/kogitoservice/deployer.go
+++ b/core/kogitoservice/deployer.go
@@ -58,8 +58,6 @@ type ServiceDefinition struct {
 	SingleReplica bool
 	// KafkaTopics is a collection of Kafka Topics to be created within the service
 	KafkaTopics []string
-	// HealthCheckProbe is the probe that needs to be configured in the service. Defaults to TCPHealthCheckProbe
-	HealthCheckProbe HealthCheckProbeType
 	// CustomService indicates that the service can be built within the cluster
 	// A custom service means that could be built by a third party, not being provided by the Kogito Team Services catalog (such as Data Index, Management Console and etc.).
 	CustomService bool

--- a/core/kogitoservice/deployment.go
+++ b/core/kogitoservice/deployment.go
@@ -56,7 +56,7 @@ func (d *deploymentHandler) CreateRequiredDeployment(service api.KogitoService, 
 		d.Log.Warn("Service can't scale vertically, only one replica is allowed.", "service", service.GetName())
 	}
 	replicas := service.GetSpec().GetReplicas()
-	probes := getProbeForKogitoService(definition, service)
+	probes := getProbeForKogitoService(service)
 	labels := service.GetSpec().GetDeploymentLabels()
 	if labels == nil {
 		labels = make(map[string]string)

--- a/core/kogitoservice/deployment_test.go
+++ b/core/kogitoservice/deployment_test.go
@@ -28,7 +28,7 @@ var defaultKogitoImageFullTag = infrastructure.GetKogitoImageVersion() + ":lates
 
 func Test_createRequiredDeployment_CheckQuarkusProbe(t *testing.T) {
 	dataIndex := test.CreateFakeDataIndex(t.Name())
-	serviceDef := ServiceDefinition{HealthCheckProbe: QuarkusHealthCheckProbe}
+	serviceDef := ServiceDefinition{}
 	cli := test.NewFakeClientBuilder().Build()
 	context := operator.Context{
 		Client: cli,
@@ -59,11 +59,11 @@ func Test_createRequiredDeployment_CheckDefaultProbe(t *testing.T) {
 	deployment := deploymentHandler.CreateRequiredDeployment(dataIndex, defaultKogitoImageFullTag, serviceDef)
 	assert.NotNil(t, deployment)
 	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket)
 	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe)
-	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket)
-	assert.Nil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet)
-	assert.Nil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet)
+	assert.Nil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket)
+	assert.Nil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket)
 }
 
 func Test_createRequiredDeployment_CheckNilEnvs(t *testing.T) {

--- a/core/kogitosupportingservice/dataindex_reconciler.go
+++ b/core/kogitosupportingservice/dataindex_reconciler.go
@@ -63,7 +63,6 @@ func (d *dataIndexSupportingServiceResource) Reconcile() (reconcileAfter time.Du
 		OnDeploymentCreate: d.dataIndexOnDeploymentCreate,
 		KafkaTopics:        dataIndexKafkaTopics,
 		Request:            controller1.Request{NamespacedName: types.NamespacedName{Name: d.instance.GetName(), Namespace: d.instance.GetNamespace()}},
-		HealthCheckProbe:   kogitoservice.QuarkusHealthCheckProbe,
 	}
 	return kogitoservice.NewServiceDeployer(d.Context, definition, d.instance, d.infraHandler).Deploy()
 }

--- a/core/kogitosupportingservice/explainability_reconciler.go
+++ b/core/kogitosupportingservice/explainability_reconciler.go
@@ -47,7 +47,6 @@ func (e *explainabilitySupportingServiceResource) Reconcile() (reconcileAfter ti
 		DefaultImageName: DefaultExplainabilityImageName,
 		Request:          controller.Request{NamespacedName: types.NamespacedName{Name: e.instance.GetName(), Namespace: e.instance.GetNamespace()}},
 		KafkaTopics:      explainabilitykafkaTopics,
-		HealthCheckProbe: kogitoservice.QuarkusHealthCheckProbe,
 	}
 	return kogitoservice.NewServiceDeployer(e.Context, definition, e.instance, e.infraHandler).Deploy()
 }

--- a/core/kogitosupportingservice/jobsservice_reconciler.go
+++ b/core/kogitosupportingservice/jobsservice_reconciler.go
@@ -54,7 +54,6 @@ func (j *jobsServiceSupportingServiceResource) Reconcile() (reconcileAfter time.
 		DefaultImageName: DefaultJobsServiceImageName,
 		Request:          controller.Request{NamespacedName: types.NamespacedName{Name: j.instance.GetName(), Namespace: j.instance.GetNamespace()}},
 		SingleReplica:    true,
-		HealthCheckProbe: kogitoservice.QuarkusHealthCheckProbe,
 		KafkaTopics:      jobsServicekafkaTopics,
 	}
 	return kogitoservice.NewServiceDeployer(j.Context, definition, j.instance, j.infraHandler).Deploy()

--- a/core/kogitosupportingservice/trustyai_reconciler.go
+++ b/core/kogitosupportingservice/trustyai_reconciler.go
@@ -53,7 +53,6 @@ func (t *trustyAISupportingServiceResource) Reconcile() (reconcileAfter time.Dur
 		DefaultImageName: DefaultTrustyImageName,
 		Request:          controller.Request{NamespacedName: types.NamespacedName{Name: t.instance.GetName(), Namespace: t.instance.GetNamespace()}},
 		KafkaTopics:      trustyAiKafkaTopics,
-		HealthCheckProbe: kogitoservice.QuarkusHealthCheckProbe,
 	}
 	return kogitoservice.NewServiceDeployer(t.Context, definition, t.instance, t.infraHandler).Deploy()
 }


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-4898

## Description
This PR changes `probe.go` to be more runtime agnostic and combines all the previous probe getters into a single catch-all `getProbe` function. The `getProbe` function returns the correct probe based on the runtime and probe type. If the handler is empty (user hasn't specified anything for it), then the returned probe will be the defaults for the specific runtime.  If the handler is not empty and is HTTP, then the path and scheme will be set if they aren't already by the user.  If the handler is not empty and is TCP, then nothing in the handler needs to be set by us since the port is required in the YAML. Finally, the probe timer values are set in all cases to not cause reconciliation problems. So in all, the runtime is only considered when the user hasn't specified anything for it, and so we use the default values for it.

## Testing
I wrote unit tests and tested all the various combinations with Quarkus/Spring Boot and HTTP/TCP on OpenShift.

## Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: 
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change
