### PR TITLE
[1.6.x][KOGITO-4993] Operator crash when data-index is created

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,5 +14,6 @@
 - [KOGITO-4905](https://issues.redhat.com/browse/KOGITO-4905) - COPY line in springboot.Dockerfile doesn't work
 - [KOGITO-4894](https://issues.redhat.com/browse/KOGITO-4894) - Remove `image` default value in KogitoRuntime CR (problem in OCP console)
 - [KOGITO-4781](https://issues.redhat.com/browse/KOGITO-4781) - Deployment constantly updates when deployed with custom probes
+- [KOGITO-4993](https://issues.redhat.com/browse/KOGITO-4993) - Operator crash when data-index is created
 
 ## Known Issues

--- a/core/manager/infra_manager.go
+++ b/core/manager/infra_manager.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	"fmt"
+
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/kiegroup/kogito-operator/api"
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
@@ -107,8 +108,11 @@ func (k *kogitoInfraManager) IsKogitoInfraReady(key types.NamespacedName) (bool,
 	if err != nil {
 		return false, err
 	}
-	conditions := *infra.GetStatus().GetConditions()
-	return meta.IsStatusConditionTrue(conditions, string(api.KogitoInfraConfigured)), nil
+	conditions := infra.GetStatus().GetConditions()
+	if conditions == nil {
+		return false, nil
+	}
+	return meta.IsStatusConditionTrue(*conditions, string(api.KogitoInfraConfigured)), nil
 }
 
 func (k *kogitoInfraManager) GetKogitoInfraFailureConditionReason(key types.NamespacedName) (string, error) {
@@ -116,8 +120,11 @@ func (k *kogitoInfraManager) GetKogitoInfraFailureConditionReason(key types.Name
 	if err != nil {
 		return "", err
 	}
-	conditions := *infra.GetStatus().GetConditions()
-	failureCondition := meta.FindStatusCondition(conditions, string(api.KogitoInfraConfigured))
+	conditions := infra.GetStatus().GetConditions()
+	if conditions == nil {
+		return "", nil
+	}
+	failureCondition := meta.FindStatusCondition(*conditions, string(api.KogitoInfraConfigured))
 	if failureCondition != nil && failureCondition.Status == v1.ConditionFalse {
 		return failureCondition.Reason, nil
 	}


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

https://issues.redhat.com/browse/KOGITO-4993

Cherrypick of https://github.com/kiegroup/kogito-operator/pull/857

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change