### PR TITLE
[KOGITO-4453] Fix getAppPropsFromConfigMap

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,5 +4,6 @@
 ## Bug Fixes
 - [KOGITO-5005](https://issues.redhat.com/browse/KOGITO-5005) - Operator print irrelevant metadata in logs
 - [KOGITO-4898](https://issues.redhat.com/browse/KOGITO-4898) - Probe defaults should be based on YAML action values
+- [KOGITO-4453](https://issues.redhat.com/browse/KOGITO-4453) - Kogito operator overwrites user's configmap provided with propertiesConfigMap
 
 ## Known Issues

--- a/core/kogitoservice/configmap.go
+++ b/core/kogitoservice/configmap.go
@@ -104,7 +104,7 @@ func getAppPropsFromConfigMap(configMap *corev1.ConfigMap, exist bool) map[strin
 		if data, ok := configMap.Data[ConfigMapApplicationPropertyKey]; ok {
 			props := strings.Split(data, "\n")
 			for _, p := range props {
-				ps := strings.Split(p, "=")
+				ps := strings.SplitN(p, "=", 2)
 				if len(ps) > 1 {
 					appProps[strings.TrimSpace(ps[0])] = strings.TrimSpace(ps[1])
 				}

--- a/core/kogitoservice/configmap_test.go
+++ b/core/kogitoservice/configmap_test.go
@@ -279,7 +279,7 @@ func Test_getAppPropsFromConfigMap(t *testing.T) {
 			args{
 				&corev1.ConfigMap{
 					Data: map[string]string{
-						ConfigMapApplicationPropertyKey: "\ntest1=test1\ntest2=test2\ntest3=test3",
+						ConfigMapApplicationPropertyKey: "\ntest1=test1\ntest2=test2\ntest3=test3 username=\"user\" password=\"pass\";",
 					},
 				},
 				true,
@@ -287,7 +287,7 @@ func Test_getAppPropsFromConfigMap(t *testing.T) {
 			map[string]string{
 				"test1": "test1",
 				"test2": "test2",
-				"test3": "test3",
+				"test3": "test3 username=\"user\" password=\"pass\";",
 			},
 		},
 	}


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-4453?focusedCommentId=16158937&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16158937

## Cause of Bug
The cause of this bug was that `getAppPropsFromConfigMap` was splitting the property value by `=` and only using the 2nd value of the split.

## Fix
I used `SplitN` to keep the rest of value after the first `=` together as it should be.

## Testing
I deployed the following YAML onto CRC, where the resulting `ConfigMap` kept all its values as they should be:
```yaml
apiVersion: app.kiegroup.org/v1beta1
kind: KogitoRuntime
metadata:
  name: qe
spec:
  replicas: 1
  image: quay.io/kmok/process-quarkus-example
  propertiesConfigMap: qe-cm
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: qe-cm
data:
  application.properties: |
    kafka.sals.mechanism=PLAIN
    kafka.security.protocol=SASL_SSL
    kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="REDACTED" password="REDACTED";
    mp.messaging.incoming.kogito_incoming_stream.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="${BAAAS_KAFKA_CLIENTID}" password="${BAAAS_KAFKA_CLIENTSECRET}";
```

I also updated the unit test for `getAppPropsFromConfigMap` to include checking that values with additional `=`'s would work.

## Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: 
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change
