### PR TITLE
BDD tests: Fix nil pointer error for KogitoInfra check

### DIFF
--- a/test/pkg/framework/kogitoinfra.go
+++ b/test/pkg/framework/kogitoinfra.go
@@ -111,8 +111,11 @@ func WaitForKogitoInfraResource(namespace, name string, timeoutInMin int) error 
 			if infraResource == nil {
 				return false, nil
 			}
-			conditions := *infraResource.GetStatus().GetConditions()
-			successCondition := meta.FindStatusCondition(conditions, string(api.KogitoInfraConfigured))
+			conditions := infraResource.GetStatus().GetConditions()
+			if conditions == nil {
+				return false, nil
+			}
+			successCondition := meta.FindStatusCondition(*conditions, string(api.KogitoInfraConfigured))
 			if successCondition == nil {
 				return false, nil
 			}


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

Happens when Kogito operator doesn't fill the conditions array before the BDD tests check conditions.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change