### PR TITLE
[KOGITO-4455] Enabling raw redeploy of Kogito Services on CLI

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,12 @@
 <!-- Keep them in alphabetical order -->
 ## Enhancements
+- [KOGITO-4455](https://issues.redhat.com/browse/KOGITO-4455) - Make Kogito Images/CLI to build a Kogito Workflow project from a workflow definition file
 - [KOGITO-4722](https://issues.redhat.com/browse/KOGITO-4722) - Support Job Service MongoDB distribution provisioning in Operator
 
 ## Bug Fixes
-- [KOGITO-5005](https://issues.redhat.com/browse/KOGITO-5005) - Operator print irrelevant metadata in logs
-- [KOGITO-4898](https://issues.redhat.com/browse/KOGITO-4898) - Probe defaults should be based on YAML action values
 - [KOGITO-4453](https://issues.redhat.com/browse/KOGITO-4453) - Kogito operator overwrites user's configmap provided with propertiesConfigMap
+- [KOGITO-4898](https://issues.redhat.com/browse/KOGITO-4898) - Probe defaults should be based on YAML action values
+- [KOGITO-5005](https://issues.redhat.com/browse/KOGITO-5005) - Operator print irrelevant metadata in logs
 - [KOGITO-5104](https://issues.redhat.com/browse/KOGITO-5104) - Kogito operator creates wrong default image tags
 
 ## Known Issues

--- a/cmd/kogito/command/deploy/delete_service_test.go
+++ b/cmd/kogito/command/deploy/delete_service_test.go
@@ -28,12 +28,12 @@ import (
 func Test_DeleteServiceCmd_SuccessfullyDelete(t *testing.T) {
 	ns := t.Name()
 	cli := fmt.Sprintf("delete-service example-drools --project %s", ns)
-	test.SetupCliTest(cli,
+	ctx := test.SetupCliTest(cli,
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
 		&v1beta1.KogitoRuntime{ObjectMeta: metav1.ObjectMeta{Name: "example-drools", Namespace: ns}})
 
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "Successfully deleted Kogito Service example-drools")
 }
@@ -41,10 +41,10 @@ func Test_DeleteServiceCmd_SuccessfullyDelete(t *testing.T) {
 func Test_DeleteServiceCmd_Failure_ServiceDoesNotExist(t *testing.T) {
 	ns := t.Name()
 	cli := fmt.Sprintf("delete-service example-drools --project %s", ns)
-	test.SetupCliTest(cli,
+	ctx := test.SetupCliTest(cli,
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
-	_, errLines, err := test.ExecuteCli()
+	_, errLines, err := ctx.ExecuteCli()
 	assert.Error(t, err)
 	assert.Contains(t, errLines, "with the name 'example-drools' doesn't exist")
 }

--- a/cmd/kogito/command/deploy/testdata/greetings.sw.json
+++ b/cmd/kogito/command/deploy/testdata/greetings.sw.json
@@ -3,37 +3,31 @@
   "version": "1.0",
   "name": "Greeting workflow",
   "description": "JSON based greeting workflow",
+  "start": "ChooseOnLanguage",
   "functions": [
     {
       "name": "greetFunction",
-      "type": "sysout"
+      "metadata": {
+        "type": "sysout"
+      }
     }
   ],
   "states": [
     {
       "name": "ChooseOnLanguage",
       "type": "switch",
-      "start": {
-        "kind": "default"
-      },
       "dataConditions": [
         {
           "condition": "{{ $.[?(@.language  == 'English')] }}",
-          "transition": {
-            "nextState": "GreetInEnglish"
-          }
+          "transition": "GreetInEnglish"
         },
         {
           "condition": "{{ $.[?(@.language  == 'Spanish')] }}",
-          "transition": {
-            "nextState": "GreetInSpanish"
-          }
+          "transition": "GreetInSpanish"
         }
       ],
       "default": {
-        "transition": {
-          "nextState": "GreetInEnglish"
-        }
+        "transition": "GreetInEnglish"
       }
     },
     {
@@ -42,9 +36,7 @@
       "data": {
         "greeting": "Hello from JSON Workflow, "
       },
-      "transition": {
-        "nextState": "GreetPerson"
-      }
+      "transition": "GreetPerson"
     },
     {
       "name": "GreetInSpanish",
@@ -52,9 +44,7 @@
       "data": {
         "greeting": "Saludos desde JSON Workflow, "
       },
-      "transition": {
-        "nextState": "GreetPerson"
-      }
+      "transition": "GreetPerson"
     },
     {
       "name": "GreetPerson",
@@ -64,14 +54,14 @@
           "name": "greetAction",
           "functionRef": {
             "refName": "greetFunction",
-            "parameters": {
+            "arguments": {
               "message": "$.greeting $.name"
             }
           }
         }
       ],
       "end": {
-        "kind": "terminate"
+        "terminate": "true"
       }
     }
   ]

--- a/cmd/kogito/command/install/kogito_infra_test.go
+++ b/cmd/kogito/command/install/kogito_infra_test.go
@@ -36,7 +36,7 @@ func Test_InstallInfraServiceCmd_DefaultConfiguration(t *testing.T) {
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
 		&v1beta1.KogitoInfra{ObjectMeta: metav1.ObjectMeta{Name: "kogito-infra", Namespace: ns}})
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "Kogito Infra Service successfully installed")
@@ -49,7 +49,7 @@ func Test_InstallInfraServiceCmd_DefaultConfiguration(t *testing.T) {
 		},
 	}
 
-	exist, err := kubernetes.ResourceC(ctx.Client).Fetch(kogitoInfra)
+	exist, err := kubernetes.ResourceC(ctx.GetClient()).Fetch(kogitoInfra)
 	assert.NoError(t, err)
 	assert.True(t, exist)
 	assert.NotNil(t, kogitoInfra)

--- a/cmd/kogito/command/install/supportingservices_test.go
+++ b/cmd/kogito/command/install/supportingservices_test.go
@@ -37,7 +37,7 @@ func Test_InstallSupportingServiceCmd_DefaultConfiguration(t *testing.T) {
 	ctx := test.SetupCliTest(cli,
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "Kogito Data Index Service successfully installed")
@@ -50,7 +50,7 @@ func Test_InstallSupportingServiceCmd_DefaultConfiguration(t *testing.T) {
 		},
 	}
 
-	exist, err := kubernetes.ResourceC(ctx.Client).Fetch(dataIndex)
+	exist, err := kubernetes.ResourceC(ctx.GetClient()).Fetch(dataIndex)
 	assert.NoError(t, err)
 	assert.True(t, exist)
 	assert.NotNil(t, dataIndex)
@@ -63,7 +63,7 @@ func Test_InstallSupportingServiceCmd_CustomConfiguration(t *testing.T) {
 	ctx := test.SetupCliTest(cli,
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "Kogito Data Index Service successfully installed")
@@ -76,7 +76,7 @@ func Test_InstallSupportingServiceCmd_CustomConfiguration(t *testing.T) {
 		},
 	}
 
-	exist, err := kubernetes.ResourceC(ctx.Client).Fetch(dataIndex)
+	exist, err := kubernetes.ResourceC(ctx.GetClient()).Fetch(dataIndex)
 	assert.NoError(t, err)
 	assert.True(t, exist)
 	assert.NotNil(t, dataIndex)

--- a/cmd/kogito/command/project/delete_project_test.go
+++ b/cmd/kogito/command/project/delete_project_test.go
@@ -31,10 +31,10 @@ func Test_DeleteProjectCmd_WhenWeSuccessfullyDelete(t *testing.T) {
 	defer teardown()
 	ns := t.Name()
 	cli := fmt.Sprintf("delete-project %s", ns)
-	test.SetupCliTest(cli,
+	ctx := test.SetupCliTest(cli,
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, fmt.Sprintf("Successfully deleted Kogito Project %s", ns))
 }
@@ -44,8 +44,8 @@ func Test_DeleteProjectCmd_WhenProjectDoesNotExist(t *testing.T) {
 	defer teardown()
 	ns := t.Name()
 	cli := fmt.Sprintf("delete-project %s", ns)
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands})
-	_, errLines, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands})
+	_, errLines, err := ctx.ExecuteCli()
 	assert.Error(t, err)
 	assert.Contains(t, errLines, fmt.Sprintf("Project %s not found", ns))
 }

--- a/cmd/kogito/command/project/display_project_test.go
+++ b/cmd/kogito/command/project/display_project_test.go
@@ -32,8 +32,8 @@ func TestDisplayProjectCmd_WhenTheresNoConfigAndNoNamespace(t *testing.T) {
 	teardown := test.OverrideKubeConfig()
 	defer teardown()
 
-	test.SetupCliTest(strings.Join([]string{"project"}, " "), context.CommandFactory{BuildCommands: BuildCommands})
-	o, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(strings.Join([]string{"project"}, " "), context.CommandFactory{BuildCommands: BuildCommands})
+	o, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, o, "No project configured")
 }
@@ -44,8 +44,8 @@ func TestDisplayProjectCmd_WhenThereIsTheNamespace(t *testing.T) {
 	defer teardown()
 
 	nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
-	test.SetupCliTest(strings.Join([]string{"project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
-	o, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(strings.Join([]string{"project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
+	o, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, o)
 	assert.Contains(t, o, "default")
@@ -57,8 +57,8 @@ func TestDisplayProjectCmd_WithJsonOutputFormat(t *testing.T) {
 	defer teardown()
 
 	nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
-	test.SetupCliTest(strings.Join([]string{"project", "-o", "json"}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
-	o, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(strings.Join([]string{"project", "-o", "json"}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
+	o, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, o)
 	assert.Contains(t, o, "\"level\":\"INFO\"")

--- a/cmd/kogito/command/project/new_project_test.go
+++ b/cmd/kogito/command/project/new_project_test.go
@@ -29,8 +29,8 @@ import (
 func TestNewProject_WhenNewProjectExist(t *testing.T) {
 	ns := t.Name()
 	cli := fmt.Sprintf("new-project --project %s", ns)
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
-	lines, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "exists")
 	assert.Contains(t, lines, ns)
@@ -41,8 +41,8 @@ func TestNewProject_WhenTheresNoNamedFlag(t *testing.T) {
 	defer teardown()
 	ns := t.Name()
 	cli := fmt.Sprintf("new-project %s", ns)
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands})
-	lines, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands})
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "created successfully")
 	assert.Contains(t, lines, ns)
@@ -50,8 +50,8 @@ func TestNewProject_WhenTheresNoNamedFlag(t *testing.T) {
 
 func TestNewProject_WhenTheresNoName(t *testing.T) {
 	cli := "new-project"
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands})
-	_, errLines, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands})
+	_, errLines, err := ctx.ExecuteCli()
 	assert.Error(t, err)
 	assert.Contains(t, errLines, "Please set a project for new-project")
 }

--- a/cmd/kogito/command/project/use_project_test.go
+++ b/cmd/kogito/command/project/use_project_test.go
@@ -33,8 +33,8 @@ func TestUseProjectCmd_WhenTheresNoConfigAndNoNamespace(t *testing.T) {
 	teardown := test.OverrideKubeConfig()
 	defer teardown()
 	ns := uuid.New().String()
-	test.SetupCliTest(strings.Join([]string{"use-project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands})
-	_, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(strings.Join([]string{"use-project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands})
+	_, _, err := ctx.ExecuteCli()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), ns)
 }
@@ -44,8 +44,8 @@ func TestUseProjectCmd_WhenThereIsTheNamespace(t *testing.T) {
 	defer teardown()
 	ns := uuid.New().String()
 	nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
-	test.SetupCliTest(strings.Join([]string{"use-project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
-	o, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(strings.Join([]string{"use-project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
+	o, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, o)
 	assert.Contains(t, o, ns)
@@ -57,8 +57,8 @@ func TestUseProjectCmd_WhenWhatIsTheNamespace_ConfigUpdated(t *testing.T) {
 	ns := t.Name()
 	nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
 	// Set the project
-	test.SetupCliTest(strings.Join([]string{"use-project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
-	o1, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest(strings.Join([]string{"use-project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
+	o1, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, o1, ns)
 	assert.Equal(t, ns, shared.GetCurrentNamespaceFromKubeConfig())
@@ -69,8 +69,8 @@ func TestUseProjectCmd_WhenWhatIsTheNamespace_UseConfigNamespace(t *testing.T) {
 	teardown := test.OverrideKubeConfigAndCreateContextInNamespace(ns)
 	defer teardown()
 	nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
-	test.SetupCliTest("use-project", context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
-	o2, _, err := test.ExecuteCli()
+	ctx := test.SetupCliTest("use-project", context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
+	o2, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, o2)
 	assert.Contains(t, o2, ns)

--- a/cmd/kogito/command/remove/kogitoinfra_test.go
+++ b/cmd/kogito/command/remove/kogitoinfra_test.go
@@ -28,12 +28,12 @@ import (
 func Test_DeleteKogitoInfraCmd_SuccessfullyDelete(t *testing.T) {
 	ns := t.Name()
 	cli := fmt.Sprintf("remove kogito-infra kafka-infra --project %s", ns)
-	test.SetupCliTest(cli,
+	ctx := test.SetupCliTest(cli,
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
 		&v1beta1.KogitoInfra{ObjectMeta: metav1.ObjectMeta{Name: "kafka-infra", Namespace: ns}})
 
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "Successfully deleted Kogito Infra Service kafka-infra")
 }
@@ -41,10 +41,10 @@ func Test_DeleteKogitoInfraCmd_SuccessfullyDelete(t *testing.T) {
 func Test_DeleteKogitoInfraCmd_Failure_ServiceDoesNotExist(t *testing.T) {
 	ns := t.Name()
 	cli := fmt.Sprintf("remove kogito-infra kafka-infra --project %s", ns)
-	test.SetupCliTest(cli,
+	ctx := test.SetupCliTest(cli,
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
-	_, errLines, err := test.ExecuteCli()
+	_, errLines, err := ctx.ExecuteCli()
 	assert.Error(t, err)
 	assert.Contains(t, errLines, "kogito Infra resource with name kafka-infra not found")
 }

--- a/cmd/kogito/command/remove/supportingservices_test.go
+++ b/cmd/kogito/command/remove/supportingservices_test.go
@@ -30,9 +30,9 @@ import (
 func Test_removeRuntimeServiceCommand_NoServiceThere(t *testing.T) {
 	ns := t.Name()
 	cli := fmt.Sprintf("remove data-index -p %s", ns)
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "There's no service data-index")
 }
@@ -40,9 +40,9 @@ func Test_removeRuntimeServiceCommand_NoServiceThere(t *testing.T) {
 func Test_removeRuntimeServiceCommand_NoServiceThereWithAlias(t *testing.T) {
 	ns := t.Name()
 	cli := fmt.Sprintf("remove management-console -p %s", ns)
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, "There's no service mgmt-console")
 }
@@ -56,9 +56,9 @@ func Test_removeRuntimeServiceCommand_SingletonService(t *testing.T) {
 			ServiceType: api.JobsService,
 		},
 	}
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, jobsService)
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, jobsService)
 
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.NotContains(t, lines, "There's no service jobs-service")
 	assert.Contains(t, lines, kogitosupportingservice.DefaultJobsServiceName)
@@ -82,9 +82,9 @@ func Test_removeRuntimeServiceCommand_MoreThenOneService(t *testing.T) {
 		},
 	}
 
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, jobsService1, jobsService2)
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, jobsService1, jobsService2)
 
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, kogitosupportingservice.DefaultJobsServiceName)
 	assert.Contains(t, lines, "my-job-service")
@@ -108,9 +108,9 @@ func Test_removeRuntimeServiceCommand_DifferentService(t *testing.T) {
 		},
 	}
 
-	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, jobsService1, jobsService2)
+	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, jobsService1, jobsService2)
 
-	lines, _, err := test.ExecuteCli()
+	lines, _, err := ctx.ExecuteCli()
 	assert.NoError(t, err)
 	assert.Contains(t, lines, kogitosupportingservice.DefaultJobsServiceName)
 	assert.NotContains(t, lines, "data-index")

--- a/cmd/kogito/command/service/build_service.go
+++ b/cmd/kogito/command/service/build_service.go
@@ -130,15 +130,9 @@ func (i buildService) InstallBuildService(flags *flag.BuildFlags, resource strin
 }
 
 func (i buildService) validatePreRequisite(flags *flag.BuildFlags, log *zap.SugaredLogger) error {
-
 	if !i.client.IsOpenshift() {
 		log.Info("Kogito Build is only supported on Openshift.")
 		return fmt.Errorf("kogito build only supported on Openshift. Provide image flag to deploy Kogito service on K8s")
-	}
-
-	// TODO: refactor all of this "services" to carry a context of shared objects
-	if err := i.resourceCheckService.CheckKogitoBuildNotExists(i.client, flags.Name, flags.Project); err != nil {
-		return err
 	}
 
 	if flags.Native {

--- a/cmd/kogito/command/service/runtime_service.go
+++ b/cmd/kogito/command/service/runtime_service.go
@@ -54,9 +54,6 @@ func NewRuntimeService() RuntimeService {
 func (i runtimeService) InstallRuntimeService(cli *client.Client, flags *flag.RuntimeFlags) (err error) {
 	log := context.GetDefaultLogger()
 	log.Debugf("Installing Kogito Runtime : %s", flags.Name)
-	if err := i.resourceCheckService.CheckKogitoRuntimeNotExists(cli, flags.Name, flags.Project); err != nil {
-		return err
-	}
 	configMap, err := converter.CreateConfigMapFromFile(cli, flags.Name, flags.Project, &flags.ConfigFlags)
 	if err != nil {
 		return err

--- a/cmd/kogito/command/shared/install_services.go
+++ b/cmd/kogito/command/shared/install_services.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kiegroup/kogito-operator/api/v1beta1"
 	"github.com/kiegroup/kogito-operator/cmd/kogito/command/context"
 	"github.com/kiegroup/kogito-operator/cmd/kogito/command/message"
+	"github.com/kiegroup/kogito-operator/cmd/kogito/core"
 	kogitocli "github.com/kiegroup/kogito-operator/core/client"
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
 )
@@ -31,6 +32,7 @@ type serviceInfoMessages struct {
 }
 
 type servicesInstallation struct {
+	manager   core.ResourceManager
 	namespace string
 	client    *kogitocli.Client
 	err       error
@@ -59,6 +61,7 @@ type ServicesInstallation interface {
 // ServicesInstallationBuilder creates the basic structure for services installation definition.
 func ServicesInstallationBuilder(client *kogitocli.Client, namespace string) ServicesInstallation {
 	return &servicesInstallation{
+		manager:   core.NewResourceManager(client),
 		namespace: namespace,
 		client:    client,
 	}
@@ -162,7 +165,7 @@ func (s *servicesInstallation) GetError() error {
 func (s *servicesInstallation) installKogitoResource(resource kubernetes.ResourceObject, messages *serviceInfoMessages) error {
 	if s.err == nil {
 		log := context.GetDefaultLogger()
-		if err := kubernetes.ResourceC(s.client).Create(resource); err != nil {
+		if err := s.manager.CreateOrUpdate(resource); err != nil {
 			return fmt.Errorf(messages.errCreating, err)
 		}
 		log.Infof(messages.installed, s.namespace)

--- a/cmd/kogito/core/doc.go
+++ b/cmd/kogito/core/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2021 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package core is meant to gather the APIs to interact with a Kubernetes server from the command line interface.
+// TODO: The shared, common and other features from package command will be moved to this one.
+// TODO: Package command must solely hold the user interface
+package core

--- a/cmd/kogito/core/resource_manager.go
+++ b/cmd/kogito/core/resource_manager.go
@@ -1,0 +1,86 @@
+// Copyright 2021 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	kogitocli "github.com/kiegroup/kogito-operator/core/client"
+	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sync"
+	"time"
+)
+
+const (
+	cancelUpdateTimeout = 30 * time.Second
+	poolWaitTimeout     = 500 * time.Millisecond
+)
+
+// ResourceManager is the API entry point for Kubernetes Resource management for CLI
+type ResourceManager interface {
+	CreateOrUpdate(resource kubernetes.ResourceObject) error
+}
+
+// NewResourceManager creates a new reference of a ResourceManager
+func NewResourceManager(client *kogitocli.Client) ResourceManager {
+	return &resourceManager{Client: client}
+}
+
+type resourceManager struct {
+	*kogitocli.Client
+}
+
+// CreateOrUpdate creates the Kubernetes Resource if it does not exist, updates otherwise
+func (r *resourceManager) CreateOrUpdate(resource kubernetes.ResourceObject) error {
+	fetchedResource := resource.DeepCopyObject()
+	exists, err := kubernetes.ResourceC(r.Client).Fetch(fetchedResource.(kubernetes.ResourceObject))
+	if err != nil {
+		return err
+	}
+	if exists {
+		return r.update(resource, fetchedResource.(kubernetes.ResourceObject))
+	}
+	return kubernetes.ResourceC(r.Client).Create(resource)
+}
+
+func (r *resourceManager) update(newResource kubernetes.ResourceObject, oldResource kubernetes.ResourceObject) error {
+	var updateError error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(res kubernetes.ResourceObject) {
+		defer wg.Done()
+		// handle race conditions
+		err := wait.Poll(poolWaitTimeout, cancelUpdateTimeout, func() (bool, error) {
+			res.SetResourceVersion(oldResource.GetResourceVersion())
+			err := kubernetes.ResourceC(r.Client).Update(res)
+			if err == nil {
+				return true, nil
+			} else if errors.IsConflict(err) {
+				_, err := kubernetes.ResourceC(r.Client).Fetch(oldResource)
+				if err != nil {
+					return false, err
+				}
+				return false, nil
+			}
+			return true, err
+		})
+		if err != nil {
+			updateError = err
+			return
+		}
+	}(newResource)
+	wg.Wait()
+	return updateError
+}

--- a/core/client/kubernetes/resource_writer.go
+++ b/core/client/kubernetes/resource_writer.go
@@ -52,7 +52,7 @@ type resourceWriter struct {
 }
 
 func (r *resourceWriter) Create(resource ResourceObject) error {
-	log.Info("Creating resource", "kind", resource.GetObjectKind().GroupVersionKind().Kind, "name", resource.GetName(), "namespace", resource.GetNamespace())
+	log.Debug("Creating resource", "kind", resource.GetObjectKind().GroupVersionKind().Kind, "name", resource.GetName(), "namespace", resource.GetNamespace())
 	if err := r.client.ControlCli.Create(context.TODO(), resource); err != nil {
 		log.Error(err, "Failed to create object. ")
 		return err
@@ -65,7 +65,7 @@ func (r *resourceWriter) Update(resource ResourceObject) error {
 	if err := r.client.ControlCli.Update(context.TODO(), resource); err != nil {
 		return err
 	}
-	log.Debug("Resource updated.", "name", resource.GetName(), "Creation Timestamp", resource.GetCreationTimestamp())
+	log.Debug("Resource updated.", "name", resource.GetName(), "Creation Timestamp", resource.GetCreationTimestamp(), "Resource", resource)
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-4455

In this PR, we enable the possibility to redeploy a given Kogito service. This is **raw** redeploy, e.g., we are just updating the object if it's already there with the parameters sent via CLI. This is meant to enable quick, and dirt incremental builds. 

I'll run some integration tests this afternoon, but don't expect too much now. We should run much more scenarios.

This will avoid the cumbersome task of deleting a service to deploy it again. :disappointed: 

PS: there's a small refactoring in the `SetupCli` functions to enable re-executing the same command, reusing the context.

Depends on https://github.com/kiegroup/kogito-images/pull/399

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change