### PR TITLE
[1.8.x] Setup External cluster use for BDD tests

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -94,8 +94,8 @@ void setupProfilingJob(String jobFolder) {
             env('CONTAINER_ENGINE', 'docker')
             env('CONTAINER_TLS_OPTIONS', '')
             env('MAX_REGISTRY_RETRIES', 3)
-            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API')
-            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS')
+            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API_EXTERNAL')
+            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS_EXTERNAL')
             
             env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
             env('MAVEN_ARTIFACT_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
@@ -165,8 +165,8 @@ void setupDeployJob(String jobFolder, KogitoJobType jobType) {
             env('CONTAINER_ENGINE', 'docker')
             env('CONTAINER_TLS_OPTIONS', '')
             env('MAX_REGISTRY_RETRIES', 3)
-            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API')
-            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS')
+            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API_EXTERNAL')
+            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS_EXTERNAL')
             env('PROPERTIES_FILE_NAME', 'deployment.properties')
 
             if (jobType == KogitoJobType.PR) {
@@ -226,8 +226,8 @@ void setupPromoteJob(String jobFolder, KogitoJobType jobType) {
             env('CONTAINER_ENGINE', 'podman')
             env('CONTAINER_TLS_OPTIONS', '--tls-verify=false')
             env('MAX_REGISTRY_RETRIES', 3)
-            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API')
-            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS')
+            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API_EXTERNAL')
+            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS_EXTERNAL')
             env('PROPERTIES_FILE_NAME', 'deployment.properties')
 
             env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
@@ -288,8 +288,8 @@ void setupExamplesImagesDeployJob(String jobFolder, KogitoJobType jobType) {
             env('CONTAINER_ENGINE', 'docker')
             env('CONTAINER_TLS_OPTIONS', '')
             env('MAX_REGISTRY_RETRIES', 3)
-            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API')
-            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS')
+            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API_EXTERNAL')
+            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS_EXTERNAL')
             env('PROPERTIES_FILE_NAME', 'deployment.properties')
 
             if (jobType == KogitoJobType.PR) {
@@ -346,8 +346,8 @@ void setupExamplesImagesPromoteJob(String jobFolder, KogitoJobType jobType) {
             env('CONTAINER_ENGINE', 'podman')
             env('CONTAINER_TLS_OPTIONS', '--tls-verify=false')
             env('MAX_REGISTRY_RETRIES', 3)
-            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API')
-            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS')
+            env('OPENSHIFT_API_KEY', 'OPENSHIFT_API_EXTERNAL')
+            env('OPENSHIFT_CREDS_KEY', 'OPENSHIFT_CREDS_EXTERNAL')
             env('PROPERTIES_FILE_NAME', 'deployment.properties')
 
             env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")

--- a/.jenkins/scripts/helper.groovy
+++ b/.jenkins/scripts/helper.groovy
@@ -326,17 +326,17 @@ Map getBDDCommonParameters(boolean runtime_app_registry_internal) {
     testParamsMap['operator_image'] = getTempOpenshiftImageName(true)
     testParamsMap['operator_tag'] = getTempTag()
 
-    String mavenRepository = env.MAVEN_ARTIFACT_REPOSITORY ?: (isRelease() ? env.DEFAULT_STAGING_REPOSITORY : '')
-    if (mavenRepository) {
-        // No mirror if we set directly the Maven repository
-        // Tests will be slower but we need to test against specific artifacts
-        testParamsMap['custom_maven_repo'] = mavenRepository
-        testParamsMap['maven_ignore_self_signed_certificate'] = true
-    }
-    if (env.MAVEN_MIRROR_REPOSITORY) {
-        testParamsMap['maven_mirror'] = env.MAVEN_MIRROR_REPOSITORY
-        testParamsMap['maven_ignore_self_signed_certificate'] = true
-    }
+    // String mavenRepository = env.MAVEN_ARTIFACT_REPOSITORY ?: (isRelease() ? env.DEFAULT_STAGING_REPOSITORY : '')
+    // if (mavenRepository) {
+    //     // No mirror if we set directly the Maven repository
+    //     // Tests will be slower but we need to test against specific artifacts
+    //     testParamsMap['custom_maven_repo'] = mavenRepository
+    //     testParamsMap['maven_ignore_self_signed_certificate'] = true
+    // }
+    // if (env.MAVEN_MIRROR_REPOSITORY) {
+    //     testParamsMap['maven_mirror'] = env.MAVEN_MIRROR_REPOSITORY
+    //     testParamsMap['maven_ignore_self_signed_certificate'] = true
+    // }
 
     if (params.EXAMPLES_REF) {
         testParamsMap['examples_ref'] = params.EXAMPLES_REF

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -171,7 +171,7 @@ pipeline {
                     // in case we decide to continue in the release
                     try {
                         // Use docker because of https://issues.redhat.com/browse/KOGITO-3512
-                        sh "make run-tests timeout=360 load_factor=1 concurrent=3 smoke=${params.SMOKE_TESTS_ONLY} ${getBDDParameters()}"
+                        sh "make run-tests timeout=360 load_factor=5 concurrent=3 smoke=${params.SMOKE_TESTS_ONLY} ${getBDDParameters()}"
                     } catch (err) {
                         unstable('Tests are failing')
                     }
@@ -249,7 +249,7 @@ String getOperatorVersion() {
 
 // Special method to get the Openshift API in the lock because env is not accessible yet
 void getLockOpenshiftApi() {
-    withCredentials([string(credentialsId: 'OPENSHIFT_API', variable: 'OPENSHIFT_API')]) {
+    withCredentials([string(credentialsId: 'OPENSHIFT_API_EXTERNAL', variable: 'OPENSHIFT_API')]) {
         return env.OPENSHIFT_API
     }
 }

--- a/Jenkinsfile.profiling
+++ b/Jenkinsfile.profiling
@@ -123,7 +123,7 @@ String getOperatorVersion() {
 
 // Special method to get the Openshift API in the lock because env is not accessible yet
 void getLockOpenshiftApi() {
-    withCredentials([string(credentialsId: 'OPENSHIFT_API', variable: 'OPENSHIFT_API')]) {
+    withCredentials([string(credentialsId: 'OPENSHIFT_API_EXTERNAL', variable: 'OPENSHIFT_API')]) {
         return env.OPENSHIFT_API
     }
 }


### PR DESCRIPTION
Our current OCP cluster on PSI is struggling to create volumes ...
Using an external cluster to run the BDD tests and to be able to launch the release.
If that works and we have the rights to keep the external cluster, I guess we should at least have the next release branch on that one to be confident in the release... let's see

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/master/RELEASE_NOTES.md) entry regarding this change
