### PR TITLE
[KOGITO-5102] - Long KogitoRuntime Name + Namespace causes Route Error in KogitoRuntime

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,5 +5,5 @@
 - [KOGITO-5512](https://issues.redhat.com/browse/KOGITO-5512) - controller-gen doesn't generate CRD's
 - [KOGITO-4470](https://issues.redhat.com/browse/KOGITO-4470) - ConfigMap required ownerReference as controller
 - [KOGITO-5573](https://issues.redhat.com/browse/KOGITO-5573) - Kogito Operator Data-Index Unable to connect to Infinispan Instance
-
+- [KOGITO-5102](https://issues.redhat.com/browse/KOGITO-5102) - Long KogitoRuntime Name + Namespace causes Route Error in KogitoRuntime
 ## Known Issues

--- a/api/kogitoservices_types.go
+++ b/api/kogitoservices_types.go
@@ -82,6 +82,7 @@ type KogitoServiceSpecInterface interface {
 	SetProbes(probes KogitoProbeInterface)
 	GetTrustStoreSecret() string
 	SetTrustStoreSecret(trustStore string)
+	GetHost() string
 }
 
 // KogitoServiceStatusInterface defines the basic interface for the Kogito Service status.

--- a/api/v1beta1/kogitoservices.go
+++ b/api/v1beta1/kogitoservices.go
@@ -246,6 +246,12 @@ type KogitoServiceSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=false
 	// +optional
 	TrustStoreSecret string `json:"trustStoreSecret,omitempty"`
+
+	// Custom hostname to be used for external Routes
+	// +optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Host"
+	Host string `json:"host,omitempty"`
 }
 
 // GetReplicas ...
@@ -400,4 +406,9 @@ func (k *KogitoServiceSpec) GetTrustStoreSecret() string {
 // SetTrustStoreSecret ...
 func (k *KogitoServiceSpec) SetTrustStoreSecret(trustStoreSecret string) {
 	k.TrustStoreSecret = trustStoreSecret
+}
+
+// GetHost returns the custom host to be used for Routes.
+func (k *KogitoServiceSpec) GetHost() string {
+	return k.Host
 }

--- a/api/v1beta1/kogitoservices.go
+++ b/api/v1beta1/kogitoservices.go
@@ -247,7 +247,7 @@ type KogitoServiceSpec struct {
 	// +optional
 	TrustStoreSecret string `json:"trustStoreSecret,omitempty"`
 
-	// Custom hostname to be used for external Routes
+	// Custom hostname to be used for OpenShift Routes
 	// +optional
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Host"

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -532,6 +532,13 @@ func schema_kiegroup_kogito_operator_api_v1beta1_KogitoSupportingServiceSpec(ref
 							Format:      "",
 						},
 					},
+					"host": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom hostname to be used for OpenShift Routes",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"serviceType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines the type for the supporting service, eg: DataIndex, JobsService Default value: JobsService",

--- a/bundle/manifests/app.kiegroup.org_kogitoruntimes.yaml
+++ b/bundle/manifests/app.kiegroup.org_kogitoruntimes.yaml
@@ -137,6 +137,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              host:
+                description: Custom hostname to be used for OpenShift Routes
+                type: string
               image:
                 description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest". On OpenShift an ImageStream will be created in the current namespace pointing to the given image.'
                 type: string

--- a/bundle/manifests/app.kiegroup.org_kogitosupportingservices.yaml
+++ b/bundle/manifests/app.kiegroup.org_kogitosupportingservices.yaml
@@ -138,6 +138,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              host:
+                description: Custom hostname to be used for OpenShift Routes
+                type: string
               image:
                 description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest". On OpenShift an ImageStream will be created in the current namespace pointing to the given image.'
                 type: string

--- a/bundle/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kogito-operator.clusterserviceversion.yaml
@@ -403,6 +403,17 @@ spec:
           - update
           - watch
         - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - sources.knative.dev
           resources:
           - sinkbindings

--- a/config/crd/bases/app.kiegroup.org_kogitoruntimes.yaml
+++ b/config/crd/bases/app.kiegroup.org_kogitoruntimes.yaml
@@ -171,6 +171,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              host:
+                description: Custom hostname to be used for OpenShift Routes
+                type: string
               image:
                 description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest".
                   On OpenShift an ImageStream will be created in the current namespace

--- a/config/crd/bases/app.kiegroup.org_kogitosupportingservices.yaml
+++ b/config/crd/bases/app.kiegroup.org_kogitosupportingservices.yaml
@@ -172,6 +172,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              host:
+                description: Custom hostname to be used for OpenShift Routes
+                type: string
               image:
                 description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest".
                   On OpenShift an ImageStream will be created in the current namespace

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -297,6 +297,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - sources.knative.dev
   resources:
   - sinkbindings

--- a/controllers/kogitoruntime_controller.go
+++ b/controllers/kogitoruntime_controller.go
@@ -15,6 +15,8 @@
 package controllers
 
 import (
+	"reflect"
+
 	"github.com/kiegroup/kogito-operator/api/v1beta1"
 	"github.com/kiegroup/kogito-operator/core/client"
 	"github.com/kiegroup/kogito-operator/core/infrastructure"
@@ -29,7 +31,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -55,6 +56,7 @@ type KogitoRuntimeReconciler struct {
 // +kubebuilder:rbac:groups=image.openshift.io,resources=imagestreams;imagestreamtags,verbs=get;create;list;watch;delete;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;roles,verbs=get;create;list;watch;delete;update
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;create;list;watch;delete;update
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=get;create;list;watch;delete;update
 // +kubebuilder:rbac:groups=core,resources=configmaps;events;pods;secrets;serviceaccounts;services,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile reads that state of the cluster for a KogitoRuntime object and makes changes based on the state read

--- a/controllers/kogitoruntime_controller_test.go
+++ b/controllers/kogitoruntime_controller_test.go
@@ -15,6 +15,8 @@
 package controllers
 
 import (
+	"testing"
+
 	"github.com/kiegroup/kogito-operator/api"
 	"github.com/kiegroup/kogito-operator/api/v1beta1"
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
@@ -22,6 +24,7 @@ import (
 	"github.com/kiegroup/kogito-operator/core/test"
 	"github.com/kiegroup/kogito-operator/meta"
 	imagev1 "github.com/openshift/api/image/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +32,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"testing"
 )
 
 func TestReconcileKogitoRuntime_Reconcile(t *testing.T) {
@@ -202,4 +204,80 @@ func TestReconcileKogitoRuntime_InvalidCustomImage(t *testing.T) {
 	failedCondition := meta2.FindStatusCondition(*instance.Status.Conditions, string(api.FailedConditionType))
 	assert.Equal(t, v1.ConditionTrue, failedCondition.Status)
 	assert.Equal(t, "you may not have access to the container image quay.io/custom/process-springboot-example-default-invalid:latest", failedCondition.Message)
+}
+
+func TestUserCustomHostValid(t *testing.T) {
+	replicas := int32(1)
+	host := "server-my-custom-route.openshift.com"
+	instance := &v1beta1.KogitoRuntime{
+		ObjectMeta: v1.ObjectMeta{Name: "process-springboot-example", Namespace: t.Name(), UID: test.GenerateUID()},
+		Spec: v1beta1.KogitoRuntimeSpec{
+			Runtime: api.SpringBootRuntimeType,
+			KogitoServiceSpec: v1beta1.KogitoServiceSpec{
+				Replicas: &replicas,
+				Image:    "quay.io/kiegroup/process-springboot-example-default:latest",
+				Host:     host,
+			},
+		},
+	}
+
+	is, tag := test.CreateFakeImageStreams("process-springboot-example-default", t.Name(), "latest")
+	err := framework.AddOwnerReference(instance, meta.GetRegisteredSchema(), is)
+	assert.NoError(t, err)
+	cli := test.NewFakeClientBuilder().AddK8sObjects(instance, is).AddImageObjects(tag).OnOpenShift().Build()
+
+	test.AssertReconcileMustNotRequeue(t, &KogitoRuntimeReconciler{Client: cli, Scheme: meta.GetRegisteredSchema(), Log: test.TestLogger}, instance)
+	_, err = kubernetes.ResourceC(cli).Fetch(instance)
+	assert.NoError(t, err)
+	assert.NotNil(t, instance.Status)
+
+	key := types.NamespacedName{Name: "process-springboot-example", Namespace: t.Name()}
+	exists, err := kubernetes.ResourceC(cli).FetchWithKey(key, &corev1.Service{})
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	route := &routev1.Route{ObjectMeta: v1.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
+	exists, err = kubernetes.ResourceC(cli).Fetch(route)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, host, route.Spec.Host)
+
+}
+
+func TestUserCustomHostInvalid(t *testing.T) {
+	replicas := int32(1)
+	host := "server-my-custom-route-that-is-over-the-valid-dns-label-length-of-63.openshift.com"
+	instance := &v1beta1.KogitoRuntime{
+		ObjectMeta: v1.ObjectMeta{Name: "process-springboot-example", Namespace: t.Name()},
+		Spec: v1beta1.KogitoRuntimeSpec{
+			Runtime: api.SpringBootRuntimeType,
+			KogitoServiceSpec: v1beta1.KogitoServiceSpec{
+				Replicas: &replicas,
+				Image:    "quay.io/kiegroup/process-springboot-example-default:latest",
+				Host:     host,
+			},
+		},
+	}
+
+	is, tag := test.CreateFakeImageStreams("process-springboot-example-default", t.Name(), "latest")
+	err := framework.AddOwnerReference(instance, meta.GetRegisteredSchema(), is)
+	assert.NoError(t, err)
+
+	cli := test.NewFakeClientBuilder().AddK8sObjects(instance, is).AddImageObjects(tag).OnOpenShift().Build()
+	test.AssertReconcileMustNotRequeue(t, &KogitoRuntimeReconciler{Client: cli, Scheme: meta.GetRegisteredSchema(), Log: test.TestLogger}, instance)
+
+	_, err = kubernetes.ResourceC(cli).Fetch(instance)
+	assert.NoError(t, err)
+	assert.NotNil(t, instance.Status)
+
+	key := types.NamespacedName{Name: "process-springboot-example", Namespace: t.Name()}
+	exists, err := kubernetes.ResourceC(cli).FetchWithKey(key, &corev1.Service{})
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	route := &routev1.Route{ObjectMeta: v1.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
+	exists, err = kubernetes.ResourceC(cli).Fetch(route)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "", route.Spec.Host)
 }

--- a/core/infrastructure/route.go
+++ b/core/infrastructure/route.go
@@ -15,6 +15,7 @@
 package infrastructure
 
 import (
+	"github.com/kiegroup/kogito-operator/api"
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
 	"github.com/kiegroup/kogito-operator/core/client/openshift"
 	"github.com/kiegroup/kogito-operator/core/operator"
@@ -28,7 +29,7 @@ import (
 type RouteHandler interface {
 	FetchRoute(key types.NamespacedName) (*routev1.Route, error)
 	GetHostFromRoute(routeKey types.NamespacedName) (string, error)
-	CreateRoute(service *corev1.Service) (route *routev1.Route)
+	CreateRoute(instance api.KogitoService, service *corev1.Service) (route *routev1.Route)
 }
 
 type routeHandler struct {
@@ -62,15 +63,17 @@ func (r *routeHandler) GetHostFromRoute(routeKey types.NamespacedName) (string, 
 }
 
 // createRequiredRoute creates a new Route resource based on the given Service
-func (r *routeHandler) CreateRoute(service *corev1.Service) (route *routev1.Route) {
+func (r *routeHandler) CreateRoute(instance api.KogitoService, service *corev1.Service) (route *routev1.Route) {
 	if service == nil || len(service.Spec.Ports) == 0 {
 		r.Log.Warn("Impossible to create a Route without a target service")
 		return route
 	}
+	host := instance.GetSpec().GetHost()
 
 	route = &routev1.Route{
 		ObjectMeta: service.ObjectMeta,
 		Spec: routev1.RouteSpec{
+			Host: host,
 			Port: &routev1.RoutePort{
 				TargetPort: intstr.FromString(service.Spec.Ports[0].Name),
 			},

--- a/core/kogitoservice/deployer_resources.go
+++ b/core/kogitoservice/deployer_resources.go
@@ -15,8 +15,9 @@
 package kogitoservice
 
 import (
-	"github.com/kiegroup/kogito-operator/core/manager"
 	"reflect"
+
+	"github.com/kiegroup/kogito-operator/core/manager"
 
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
@@ -77,7 +78,7 @@ func (s *serviceDeployer) createRequiredResources(image string) (resources map[r
 	resources[reflect.TypeOf(corev1.Service{})] = []resource.KubernetesResource{service}
 	if s.Client.IsOpenshift() {
 		routeHandler := infrastructure.NewRouteHandler(s.Context)
-		resources[reflect.TypeOf(routev1.Route{})] = []resource.KubernetesResource{routeHandler.CreateRoute(service)}
+		resources[reflect.TypeOf(routev1.Route{})] = []resource.KubernetesResource{routeHandler.CreateRoute(s.instance, service)}
 	}
 
 	if err := s.onObjectsCreate(resources); err != nil {

--- a/go.sum
+++ b/go.sum
@@ -99,7 +99,6 @@ github.com/Azure/azure-service-bus-go v0.9.1/go.mod h1:yzBx6/BUGfjfeqbRZny9AQIbI
 github.com/Azure/azure-storage-blob-go v0.0.0-20190123011202-457680cc0804/go.mod h1:oGfmITT1V6x//CswqY2gtAHND+xIP64/qL7a5QJix0Y=
 github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxwl2B6teiRqI0deQUvsw0=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
-github.com/Azure/go-autorest v13.3.2+incompatible h1:VxzPyuhtnlBOzc4IWCZHqpyH2d+QMLQEuy3wREyY4oc=
 github.com/Azure/go-autorest v13.3.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.1.0/go.mod h1:AKyIcETwSUFxIcs/Wnq/C+kwCtlEYGUVd7FPNb2slmg=
 github.com/Azure/go-autorest/autorest v0.2.0/go.mod h1:AKyIcETwSUFxIcs/Wnq/C+kwCtlEYGUVd7FPNb2slmg=
@@ -109,7 +108,6 @@ github.com/Azure/go-autorest/autorest v0.9.3/go.mod h1:GsRuLYvwzLjjjRoWEIyMUaYq8
 github.com/Azure/go-autorest/autorest v0.9.6/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest v0.10.0/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest v0.10.2/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
-github.com/Azure/go-autorest/autorest v0.11.1 h1:eVvIXUKiTgv++6YnWb42DUA1YL7qDugnKP0HljexdnQ=
 github.com/Azure/go-autorest/autorest v0.11.1/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
 github.com/Azure/go-autorest/autorest/adal v0.1.0/go.mod h1:MeS4XhScH55IST095THyTxElntu7WqB7pNbZo8Q5G3E=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
@@ -119,13 +117,11 @@ github.com/Azure/go-autorest/autorest/adal v0.8.1/go.mod h1:ZjhuQClTqx435SRJ2iMl
 github.com/Azure/go-autorest/autorest/adal v0.8.2/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
 github.com/Azure/go-autorest/autorest/adal v0.8.3/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
 github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
-github.com/Azure/go-autorest/autorest/adal v0.9.5 h1:Y3bBUV4rTuxenJJs41HU3qmqsb+auo+a3Lz+PlJPpL0=
 github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
 github.com/Azure/go-autorest/autorest/azure/auth v0.4.2/go.mod h1:90gmfKdlmKgfjUpnCEpOJzsUEjrWDSLwHIG73tSXddM=
 github.com/Azure/go-autorest/autorest/azure/cli v0.3.1/go.mod h1:ZG5p860J94/0kI9mNJVoIoLgXcirM2gF5i2kWloofxw=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
-github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
@@ -140,11 +136,9 @@ github.com/Azure/go-autorest/autorest/validation v0.1.0/go.mod h1:Ha3z/SqBeaalWQ
 github.com/Azure/go-autorest/autorest/validation v0.2.0/go.mod h1:3EEqHnBxQGHXRYq3HT1WyXAvT7LLY3tl70hw6tQIbjI=
 github.com/Azure/go-autorest/autorest/validation v0.2.1-0.20191028180845-3492b2aff503/go.mod h1:3EEqHnBxQGHXRYq3HT1WyXAvT7LLY3tl70hw6tQIbjI=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
-github.com/Azure/go-autorest/logger v0.2.0 h1:e4RVHVZKC5p6UANLJHkM4OfR1UKZPj8Wt8Pcx+3oqrE=
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.1.0/go.mod h1:ROEEAFwXycQw7Sn3DXNtEedEvdeRAgDr0izn4z5Ij88=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
-github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
@@ -537,7 +531,6 @@ github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -610,7 +603,6 @@ github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwds
 github.com/go-openapi/jsonpointer v0.17.2/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
-github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -619,7 +611,6 @@ github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3Hfo
 github.com/go-openapi/jsonreference v0.17.2/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
-github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/jsonreference v0.19.5 h1:1WJP/wi4OjB4iV8KVbH73rQaoialJrqv8gitZLxGLtM=
 github.com/go-openapi/jsonreference v0.19.5/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE69AqPYEJeo/TWfEeg=
@@ -645,7 +636,6 @@ github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcs
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/spec v0.19.6/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
-github.com/go-openapi/spec v0.19.7 h1:0xWSeMd35y5avQAThZR2PkEuqSosoS5t6gDH4L8n11M=
 github.com/go-openapi/spec v0.19.7/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/spec v0.19.15 h1:uxh8miNJEfMm8l8ekpY7i39LcORm1xSRtoipEGl1JPk=
 github.com/go-openapi/spec v0.19.15/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
@@ -665,7 +655,6 @@ github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.4/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.7/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
-github.com/go-openapi/swag v0.19.9 h1:1IxuqvBUU3S2Bi4YC7tlP9SJF1gVpCvqN0T2Qof4azE=
 github.com/go-openapi/swag v0.19.9/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
 github.com/go-openapi/swag v0.19.12 h1:Bc0bnY2c3AoF7Gc+IMIAQQsD8fLHjHpc19wXvYuayQI=
 github.com/go-openapi/swag v0.19.12/go.mod h1:eFdyEBkTdoAf/9RXBvj4cr1nH7GD8Kzo5HTt47gr72M=
@@ -799,7 +788,6 @@ github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
@@ -1137,7 +1125,6 @@ github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/compress v1.9.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.10.2 h1:Znfn6hXZAHaLPNnlqUYRrBSReFHYybslgv4PTiyz6P0=
 github.com/klauspost/compress v1.10.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
@@ -1200,7 +1187,6 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.1-0.20191009090205-6c0755d89d1e/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
@@ -2541,7 +2527,6 @@ k8s.io/client-go v0.20.4/go.mod h1:LiMv25ND1gLUdBeYxBIwKpkSC5IsozMMmOOeSJboP+k=
 k8s.io/cloud-provider v0.18.8/go.mod h1:cn9AlzMPVIXA4HHLVbgGUigaQlZyHSZ7WAwDEFNrQSs=
 k8s.io/cluster-bootstrap v0.18.8/go.mod h1:guq0Uc+QwazHgpS1yAw5Z7yUlBCtGppbgWQkbN3lxIY=
 k8s.io/code-generator v0.18.8/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
-k8s.io/component-base v0.18.8 h1:BW5CORobxb6q5mb+YvdwQlyXXS6NVH5fDXWbU7tf2L8=
 k8s.io/component-base v0.18.8/go.mod h1:00frPRDas29rx58pPCxNkhUfPbwajlyyvu8ruNgSErU=
 k8s.io/cri-api v0.18.8/go.mod h1:OJtpjDvfsKoLGhvcc0qfygved0S0dGX56IJzPbqTG1s=
 k8s.io/csi-translation-lib v0.18.8/go.mod h1:6cA6Btlzxy9s3QrS4BCZzQqclIWnTLr6Jx3H2ctAzY4=
@@ -2574,7 +2559,6 @@ k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d/go.mod h1:1TqjTSzOxsLGIKf
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=
-k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd h1:sOHNzJIkytDF6qadMNKhhDRpc6ODik8lVC6nOur7B2c=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -2858,6 +2858,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - sources.knative.dev
   resources:
   - sinkbindings

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -1139,6 +1139,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              host:
+                description: Custom hostname to be used for OpenShift Routes
+                type: string
               image:
                 description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest".
                   On OpenShift an ImageStream will be created in the current namespace
@@ -1909,6 +1912,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              host:
+                description: Custom hostname to be used for OpenShift Routes
+                type: string
               image:
                 description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest".
                   On OpenShift an ImageStream will be created in the current namespace

--- a/profiling/kogito-operator-profiling.yaml
+++ b/profiling/kogito-operator-profiling.yaml
@@ -2858,6 +2858,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - sources.knative.dev
   resources:
   - sinkbindings

--- a/profiling/kogito-operator-profiling.yaml
+++ b/profiling/kogito-operator-profiling.yaml
@@ -1139,6 +1139,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              host:
+                description: Custom hostname to be used for OpenShift Routes
+                type: string
               image:
                 description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest".
                   On OpenShift an ImageStream will be created in the current namespace
@@ -1909,6 +1912,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              host:
+                description: Custom hostname to be used for OpenShift Routes
+                type: string
               image:
                 description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest".
                   On OpenShift an ImageStream will be created in the current namespace


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-5102

## Description
When deploying a KogitoRuntime on OpenShift where `<name>-<namespace>` combined is longer than 63 characters, Kogito fails to create a route because the host does not conform to DNS 1123 naming conventions.

For this fix I added a spec.host field to the KogitoRuntime CRD to allow users to manually set a custom host. In addition, the host input is validated before route creation and defaults to the original route creation steps if host is invalid.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've ran `make before-pr` and everything is working accordingly
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change
