### PR TITLE
[KOGITO-4791] Add metrics related files back in the operator bundle

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,4 +10,6 @@
 - [KOGITO-5573](https://issues.redhat.com/browse/KOGITO-5573) - Kogito Operator Data-Index Unable to connect to Infinispan Instance
 - [KOGITO-5811](https://issues.redhat.com/browse/KOGITO-5811) - no kind is registered for the type v1beta1.KogitoInfra
 - [KOGITO-5740](https://issues.redhat.com/browse/KOGITO-5740) - Unnecessary reconciliations triggered for Service
+- [KOGITO-4791](https://issues.redhat.com/browse/KOGITO-4791) - Add metrics related files back in the operator bundle
+
 ## Known Issues

--- a/hack/create-olm-manifests.sh
+++ b/hack/create-olm-manifests.sh
@@ -34,7 +34,3 @@ cp bundle.Dockerfile "${MANIFESTS}/Dockerfile"
 sed -i "s|bundle/manifests|manifests|g"  "${MANIFESTS}/Dockerfile"
 sed -i "s|bundle/metadata|metadata|g"    "${MANIFESTS}/Dockerfile"
 sed -i "s|bundle/tests|tests|g"          "${MANIFESTS}/Dockerfile"
-
-#removing metrics files, due to KOGITO-4547, once the issue or the upstream issue https://github.com/operator-framework/operator-lifecycle-manager/issues/2019 is resolved we can remove the lines below
-rm "${MANIFESTS}/manifests/kogito-operator-controller-manager-metrics-service_v1_service.yaml"
-rm "${MANIFESTS}/manifests/kogito-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml"


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

https://issues.redhat.com/browse/KOGITO-4791

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change
