### PR TITLE
[KOGITO-6230] Do not set GOOS/GOARCH

### DIFF
--- a/hack/go-build-cli.sh
+++ b/hack/go-build-cli.sh
@@ -74,6 +74,6 @@ if [ "$release" = "true" ]; then
   echo "--- Finishing building Kogito CLI ${version}"
 else
   packTemplateFiles
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -a -o build/_output/bin/kogito github.com/kiegroup/kogito-operator/cmd/kogito
+  CGO_ENABLED=0 go build -v -a -o build/_output/bin/kogito github.com/kiegroup/kogito-operator/cmd/kogito
   cleanTemplateFiles
 fi

--- a/hack/go-install-cli.sh
+++ b/hack/go-install-cli.sh
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 cd cmd/kogito || exit
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install
+CGO_ENABLED=0 go install

--- a/modules/org.kie.kogito.app.buildProfilingOperator/install.sh
+++ b/modules/org.kie.kogito.app.buildProfilingOperator/install.sh
@@ -2,4 +2,4 @@
 set -e
 cd /workspace
 
-GOOS=linux GOARCH=amd64 go test -covermode=atomic -coverpkg=github.com/kiegroup/kogito-operator/... -c -tags testrunmain ./ -o manager
+go test -covermode=atomic -coverpkg=github.com/kiegroup/kogito-operator/... -c -tags testrunmain ./ -o manager

--- a/modules/org.kie.kogito.app.builder/install.sh
+++ b/modules/org.kie.kogito.app.builder/install.sh
@@ -2,4 +2,4 @@
 set -e
 cd /workspace
 
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+CGO_ENABLED=0 GO111MODULE=on go build -a -o manager main.go

--- a/modules/org.kie.kogito.rhpam.builder/install.sh
+++ b/modules/org.kie.kogito.rhpam.builder/install.sh
@@ -6,5 +6,5 @@ if [ -n "$CACHITO_ENV_FILE" ]; then
   cp $REMOTE_SOURCE_DIR/app/rhpam-kogito-operator-manager /workspace
 else
   cd /workspace
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o rhpam-kogito-operator-manager main.go;
+  CGO_ENABLED=0 GO111MODULE=on go build -a -o rhpam-kogito-operator-manager main.go;
 fi


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-6230

- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
﻿golang automatically compiles natively, and explicitly setting these
prevents multi-architecture builds from working.
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>
