### PR TITLE
Updated GHA: cache is specific to Go version

### DIFF
--- a/.github/workflows/Kogito-Operator-OLM-tests.yaml
+++ b/.github/workflows/Kogito-Operator-OLM-tests.yaml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod/cache
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-cache-
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-
       - name: Cache the binaries
         uses: actions/cache@v1
         with:
@@ -44,9 +44,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: go.mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-mod-${{ hashFiles('**/go.mod') }}
           restore-keys: |
-            ${{ runner.os }}-go-mod-
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-mod-
       - run: go mod tidy
       - name: Install Cekit and dependencies
         run: |

--- a/.github/workflows/Kogito-Operator-PR-Check.yaml
+++ b/.github/workflows/Kogito-Operator-PR-Check.yaml
@@ -26,16 +26,16 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod/cache
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-cache-
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-
       - name: Cache the binaries
         uses: actions/cache@v1
         with:
           path: ~/go/bin/
-          key: ${{ runner.os }}-go-v1-${{ hashFiles(format('{0}/bin', env.GOPATH)) }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v1-${{ hashFiles(format('{0}/bin', env.GOPATH)) }}
           restore-keys: |
-            ${{ runner.os }}-go-v1-${{ hashFiles(format('{0}/bin', env.GOPATH)) }}
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-v1-${{ hashFiles(format('{0}/bin', env.GOPATH)) }}
       - name: Install Operator-sdk
         run: ./hack/ci/install-operator-sdk.sh
       - name: Check Vet

--- a/.github/workflows/Kogito-Operator-Unit-tests.yaml
+++ b/.github/workflows/Kogito-Operator-Unit-tests.yaml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod/cache
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-cache-
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-
       - name: Install cover
         run: go get golang.org/x/tools/cmd/cover
       - name: Validate codcov yaml file


### PR DESCRIPTION
So when we execute the GHA on different branches with different go version, there is no conflict...

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [ ] Pull Request contains a description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>