### PR TITLE
disable_clean_cluster on build-examples-images

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -155,7 +155,7 @@ run-tests:
 
 .PHONY: build-examples-images
 build-examples-images:
-	make run-tests test_main_dir=./examples feature=../features cr_deployment_only=true
+	make run-tests test_main_dir=./examples feature=../features cr_deployment_only=true disable_clean_cluster=true
 
 .PHONY: run-smoke-tests
 run-smoke-tests:


### PR DESCRIPTION
To avoid cleaning up the cluster whereas other tests are running and we don't need it really ...

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [ ] Pull Request contains a description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>