### PR TITLE
[1.11.x] BDD tests: Handle different URL for archetype mirror URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ All options from BDD tests do also apply here.
 | @trustyui          | Tests including Trusty UI                                                          |
 |                    |                                                                                    |
 | @binary            | Tests using Kogito applications built locally and uploaded to OCP as a binary file |
+| @asset             | Tests using Kogito applications built from assets uploaded to OCP                  |
 | @native            | Tests using native build                                                           |
 | @nonnativelts      | Tests using native build that cannot be tested with Quarkus LTS version            |
 | @persistence       | Tests verifying persistence capabilities                                           |

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -91,6 +91,7 @@ function usage(){
   printf "\n--custom_maven_repo {URI}\n\tSet a custom Maven repository url for S2I builds, in case your artifacts are in a specific repository. See https://github.com/kiegroup/kogito-images/README.md for more information."
   printf "\n--custom_maven_repo_replace_default\n\tIf you specified the option 'custom_maven_repo' and you want that one to replace the main JBoss repository (useful with snapshots)."
   printf "\n--maven_mirror {URI}\n\tMaven mirror url to be used when building app in the tests."
+  printf "\n--archetype_maven_mirror {URI}\n\tMaven mirror url to be used when building app from source files."
   printf "\n--maven_ignore_self_signed_certificate\n\tSet to true if maven build need to ignore self-signed certificate. This could happen when using internal maven mirror url."
   printf "\n--build_image_registry {REGISTRY}\n\tSet the build image registry."
   printf "\n--build_image_namespace {NAMESPACE}\n\tSet the build image namespace."
@@ -394,6 +395,10 @@ case $1 in
   --maven_mirror)
     shift
     if addParamKeyValueIfAccepted "--tests.maven-mirror-url" ${1}; then shift; fi
+  ;;
+  --archetype_maven_mirror)
+    shift
+    if addParamKeyValueIfAccepted "--tests.archetype-maven-mirror-url" ${1}; then shift; fi
   ;;
   --maven_ignore_self_signed_certificate)
     addParam "--tests.maven-ignore-self-signed-certificate"

--- a/hack/run-tests.sh.bats
+++ b/hack/run-tests.sh.bats
@@ -833,6 +833,24 @@ export -f oc
     [[ "${output}" != *"--tests.maven-mirror-url"* ]]
 }
 
+@test "invoke run-tests with archetype_maven_mirror" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --archetype_maven_mirror maven --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "--tests.archetype-maven-mirror-url=maven" ]]
+}
+
+@test "invoke run-tests with archetype_maven_mirror missing value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --archetype_maven_mirror --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.archetype-maven-mirror-url"* ]]
+}
+
+@test "invoke run-tests with archetype_maven_mirror empty value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --archetype_maven_mirror "" --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.archetype-maven-mirror-url"* ]]
+}
+
 @test "invoke run-tests with maven_ignore_self_signed_certificate" {
     run ${BATS_TEST_DIRNAME}/run-tests.sh --maven_ignore_self_signed_certificate --dry_run
     [ "$status" -eq 0 ]

--- a/test/Makefile
+++ b/test/Makefile
@@ -51,6 +51,7 @@ runtime_application_image_version=
 custom_maven_repo=
 custom_maven_repo_replace_default=false
 maven_mirror=
+archetype_maven_mirror_url=
 maven_ignore_self_signed_certificate=false
 build_image_registry=
 build_image_namespace=
@@ -131,6 +132,7 @@ run-tests:
 		--runtime_application_image_version ${runtime_application_image_version} \
 		--custom_maven_repo $(custom_maven_repo) \
 		--maven_mirror $(maven_mirror) \
+		--archetype_maven_mirror $(archetype_maven_mirror) \
 		--build_image_registry ${build_image_registry} \
 		--build_image_namespace ${build_image_namespace} \
 		--build_image_name_suffix ${build_image_name_suffix} \

--- a/test/features/deploy_source_files.feature
+++ b/test/features/deploy_source_files.feature
@@ -1,4 +1,5 @@
 @rhpam
+@asset
 Feature: Deploy source files (dmn, drl, bpmn, bpmn2, ...) with CLI
 
   Background:

--- a/test/pkg/config/config.go
+++ b/test/pkg/config/config.go
@@ -75,6 +75,7 @@ type TestConfig struct {
 	customMavenRepoURL                 string
 	customMavenRepoReplaceDefault      bool
 	mavenMirrorURL                     string
+	archetypeMavenMirrorURL            string
 	mavenIgnoreSelfSignedCertificate   bool
 	buildImageRegistry                 string
 	buildImageNamespace                string
@@ -188,6 +189,7 @@ func BindFlags(set *flag.FlagSet) {
 	set.StringVar(&env.customMavenRepoURL, prefix+"custom-maven-repo-url", "", "Set a custom Maven repository url for S2I builds, in case your artifacts are in a specific repository. See https://github.com/kiegroup/kogito-images/README.md for more information")
 	set.BoolVar(&env.customMavenRepoReplaceDefault, prefix+"custom-maven-repo-replace-default", false, "If you specified the option 'tests.custom-maven-repo-url' and you want that one to replace the main JBoss repository (useful with snapshots).")
 	set.StringVar(&env.mavenMirrorURL, prefix+"maven-mirror-url", "", "Maven mirror url to be used when building app in the tests")
+	set.StringVar(&env.archetypeMavenMirrorURL, prefix+"archetype-maven-mirror-url", "", "Archetype maven mirror url to be used when building app from asset files")
 	set.BoolVar(&env.mavenIgnoreSelfSignedCertificate, prefix+"maven-ignore-self-signed-certificate", false, "Set to true if maven build need to ignore self-signed certificate. This could happen when using internal maven mirror url.")
 	set.StringVar(&env.buildImageRegistry, prefix+"build-image-registry", "", "Set the build image registry")
 	set.StringVar(&env.buildImageNamespace, prefix+"build-image-namespace", "", "Set the build image namespace")
@@ -434,6 +436,11 @@ func IsCustomMavenRepoReplaceDefault() bool {
 // GetMavenMirrorURL return the maven mirror url used for building applications
 func GetMavenMirrorURL() string {
 	return env.mavenMirrorURL
+}
+
+// GetArchetypeMavenMirrorURL return the maven mirror url used for building applications from assets
+func GetArchetypeMavenMirrorURL() string {
+	return env.archetypeMavenMirrorURL
 }
 
 // IsMavenIgnoreSelfSignedCertificate return whether self-signed certficate should be ignored

--- a/test/pkg/steps/deploy_files.go
+++ b/test/pkg/steps/deploy_files.go
@@ -55,6 +55,10 @@ func deploySourceFilesFromPath(namespace, runtimeType, serviceName, path string)
 	buildHolder.KogitoBuild.GetSpec().SetType(api.LocalSourceBuildType)
 	buildHolder.KogitoBuild.GetSpec().GetGitSource().SetURI(path)
 
+	if runtimeType == "quarkus" && len(config.GetArchetypeMavenMirrorURL()) > 0 {
+		buildHolder.KogitoBuild.GetSpec().SetMavenMirrorURL(config.GetArchetypeMavenMirrorURL())
+	}
+
 	err = framework.DeployKogitoBuild(namespace, framework.GetDefaultInstallerType(), buildHolder)
 	if err != nil {
 		return err

--- a/test/pkg/steps/deploy_files.go
+++ b/test/pkg/steps/deploy_files.go
@@ -55,9 +55,7 @@ func deploySourceFilesFromPath(namespace, runtimeType, serviceName, path string)
 	buildHolder.KogitoBuild.GetSpec().SetType(api.LocalSourceBuildType)
 	buildHolder.KogitoBuild.GetSpec().GetGitSource().SetURI(path)
 
-	framework.GetLogger(namespace).Info(fmt.Sprintf("archetype URL is %s and runtimeType is %s", config.GetArchetypeMavenMirrorURL(), runtimeType))
 	if runtimeType == "quarkus" && len(config.GetArchetypeMavenMirrorURL()) > 0 {
-		framework.GetLogger(namespace).Info("Set Maven mirror URL to " + config.GetArchetypeMavenMirrorURL())
 		buildHolder.KogitoBuild.GetSpec().SetMavenMirrorURL(config.GetArchetypeMavenMirrorURL())
 	}
 

--- a/test/pkg/steps/deploy_files.go
+++ b/test/pkg/steps/deploy_files.go
@@ -55,7 +55,9 @@ func deploySourceFilesFromPath(namespace, runtimeType, serviceName, path string)
 	buildHolder.KogitoBuild.GetSpec().SetType(api.LocalSourceBuildType)
 	buildHolder.KogitoBuild.GetSpec().GetGitSource().SetURI(path)
 
+	framework.GetLogger(namespace).Info(fmt.Sprintf("archetype URL is %s and runtimeType is %s", config.GetArchetypeMavenMirrorURL(), runtimeType))
 	if runtimeType == "quarkus" && len(config.GetArchetypeMavenMirrorURL()) > 0 {
+		framework.GetLogger(namespace).Info("Set Maven mirror URL to " + config.GetArchetypeMavenMirrorURL())
 		buildHolder.KogitoBuild.GetSpec().SetMavenMirrorURL(config.GetArchetypeMavenMirrorURL())
 	}
 


### PR DESCRIPTION
Similarly to what has been done for [kogito-images](https://github.com/kiegroup/kogito-images/commit/b91a8059c7542cd46f72f80ae0b4eda64c5fbb1d), we need a way to specify a specific build of the quarkus platform.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [ ] Pull Request contains a description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>