### PR TITLE
[1.11.x] KOGITO-5531 Update Jenkins CI to Maven 3.8.1

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -10,6 +10,7 @@ pipeline {
     // Needed for local build
     tools {
         jdk 'kie-jdk11'
+        maven 'kie-maven-3.8.1'
         go 'golang-1.14'
     }
 

--- a/.ci/jenkins/Jenkinsfile.examples-images.deploy
+++ b/.ci/jenkins/Jenkinsfile.examples-images.deploy
@@ -10,6 +10,7 @@ pipeline {
     // Needed for local build
     tools {
         jdk 'kie-jdk11'
+        maven 'kie-maven-3.8.1'
         go 'golang-1.14'
     }
 

--- a/.ci/jenkins/Jenkinsfile.profiling
+++ b/.ci/jenkins/Jenkinsfile.profiling
@@ -10,6 +10,7 @@ pipeline {
     // Needed for local build
     tools {
         jdk 'kie-jdk11'
+        maven 'kie-maven-3.8.1'
         go 'golang-1.14'
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5531

Required by Quarkus 2.2 branch.

cherry-pick: https://github.com/kiegroup/kogito-operator/pull/1123

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1961
- https://github.com/kiegroup/optaplanner/pull/1819
- https://github.com/kiegroup/kogito-apps/pull/1223
- https://github.com/kiegroup/kogito-examples/pull/1108
- https://github.com/kiegroup/kogito-operator/pull/1124