### PR TITLE
[KOGITO-2787] Unify namespace/project wording in logs and Kogito CLI

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,5 +3,5 @@
 
 ## Bug Fixes
 - [KOGITO-6414](https://issues.redhat.com/browse/KOGITO-6414) - Operator fails reconciliation when specific KafkaTopic exists
-
+- [KOGITO-2787](https://issues.redhat.com/browse/KOGITO-2787) - Unify namespace/project wording in logs and Kogito CLI
 ## Known Issues

--- a/cmd/kogito/command/deploy/delete_service.go
+++ b/cmd/kogito/command/deploy/delete_service.go
@@ -54,8 +54,12 @@ func (i *deleteServiceCommand) RegisterHook() {
 	i.command = &cobra.Command{
 		Example: "delete-service example-drools --project kogito",
 		Use:     "delete-service NAME [flags]",
-		Short:   "Deletes a Kogito service deployed in the namespace/project",
-		Long:    `delete-service will exclude every OpenShift/Kubernetes resource created to deploy the Kogito Service into the namespace.`,
+		Short:   "Deletes a Kogito service deployed in the given Project context",
+		Long: `delete-service will exclude every OpenShift/Kubernetes resource created to deploy the Kogito Service into the Project context.
+		Project context is the namespace (Kubernetes) or project (OpenShift) where the Service will be deployed.
+		To know what's your context, use "kogito project". To set a new Project in the context use "kogito use-project NAME".
+		Please note that this command requires the Kogito Operator installed in the cluster.
+		For more information about the Kogito Operator installation please refer to https://github.com/kiegroup/kogito-operator#kogito-operator-installation.`,
 		RunE:    i.Exec,
 		PreRun:  i.CommonPreRun,
 		PostRun: i.CommonPostRun,

--- a/cmd/kogito/command/deploy/deploy_service.go
+++ b/cmd/kogito/command/deploy/deploy_service.go
@@ -63,7 +63,7 @@ func (i *deployCommand) Command() *cobra.Command {
 func (i *deployCommand) RegisterHook() {
 	i.command = &cobra.Command{
 		Use:     "deploy-service NAME [SOURCE]",
-		Short:   "Deploys a new Kogito Service into the given Project",
+		Short:   "Deploys a new Kogito Service into the given Project context",
 		Aliases: []string{"deploy"},
 		Long: `deploy-service will create a new Kogito service in the Project context.
 	Providing a directory containing a pom.xml file in root will upload the whole directory for s2i build on the cluster.

--- a/cmd/kogito/command/flag/install_flag.go
+++ b/cmd/kogito/command/flag/install_flag.go
@@ -45,7 +45,7 @@ func AddInstallFlags(command *cobra.Command, flags *InstallFlags) {
 	AddMonitoringFlags(command, &flags.MonitoringFlags)
 	AddConfigFlags(command, &flags.ConfigFlags)
 	AddProbeFlags(command, &flags.ProbeFlags)
-	command.Flags().StringVarP(&flags.Project, "project", "p", "", "The project name where the service will be deployed")
+	command.Flags().StringVarP(&flags.Project, "project", "p", "", "The project context name where the service will be deployed")
 	command.Flags().Int32Var(&flags.Replicas, "replicas", defaultDeployReplicas, "Number of pod replicas that should be deployed.")
 	command.Flags().StringArrayVar(&flags.Infra, "infra", nil, "Dependent KogitoInfra objects. Can be set more than once.")
 	command.Flags().StringVar(&flags.TrustStoreSecret, "truststore-secret", "", "Name of the Secret containing the custom JKS TrustStore")

--- a/cmd/kogito/command/project/delete_project_test.go
+++ b/cmd/kogito/command/project/delete_project_test.go
@@ -47,5 +47,5 @@ func Test_DeleteProjectCmd_WhenProjectDoesNotExist(t *testing.T) {
 	ctx := test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands})
 	_, errLines, err := ctx.ExecuteCli()
 	assert.Error(t, err)
-	assert.Contains(t, errLines, fmt.Sprintf("Project %s not found", ns))
+	assert.Contains(t, errLines, fmt.Sprintf("Project context (namespace) %s not found. Try setting your project context using 'kogito use-project NAME' \n", ns))
 }

--- a/cmd/kogito/command/remove/kogitoinfra.go
+++ b/cmd/kogito/command/remove/kogitoinfra.go
@@ -73,7 +73,7 @@ func (i *deleteKogitoInfraServiceCommand) Command() *cobra.Command {
 func (i *deleteKogitoInfraServiceCommand) InitHook() {
 	i.flags = &deleteKogitoInfraFlags{}
 	i.Parent.AddCommand(i.command)
-	i.command.Flags().StringVarP(&i.flags.project, "project", "p", "", "The project name from where the service needs to be deleted")
+	i.command.Flags().StringVarP(&i.flags.project, "project", "p", "", "The project context name from where the service needs to be deleted")
 }
 
 func (i *deleteKogitoInfraServiceCommand) Exec(cmd *cobra.Command, args []string) (err error) {
@@ -94,6 +94,6 @@ func (i *deleteKogitoInfraServiceCommand) Exec(cmd *cobra.Command, args []string
 	}); err != nil {
 		return err
 	}
-	log.Infof("Successfully deleted Kogito Infra Service %s in the Project %s", i.flags.name, i.flags.project)
+	log.Infof("Successfully deleted Kogito Infra Service %s in the Project context %s", i.flags.name, i.flags.project)
 	return nil
 }

--- a/cmd/kogito/command/shared/resource_checks.go
+++ b/cmd/kogito/command/shared/resource_checks.go
@@ -83,7 +83,7 @@ func checkProjectExists(kubeCli *client.Client, namespace string) error {
 	if ns, err := kubernetes.NamespaceC(kubeCli).Fetch(namespace); err != nil {
 		return fmt.Errorf("Error while trying to fetch for the application context (namespace): %s ", err)
 	} else if ns == nil {
-		return fmt.Errorf("Project %s not found. Try setting your project using 'kogito use-project NAME' ", namespace)
+		return fmt.Errorf("Project context (namespace) %s not found. Try setting your project context using 'kogito use-project NAME' ", namespace)
 	}
 	log.Debugf("Namespace '%s' exists", namespace)
 	return nil
@@ -97,7 +97,7 @@ func (r resourceCheckServiceImpl) CheckKogitoRuntimeExists(kubeCli *client.Clien
 	} else if !exists {
 		return fmt.Errorf("Looks like a Kogito runtime with the name '%s' doesn't exist in this project. Please try another name ", name)
 	} else {
-		log.Debugf("Kogito runtime with name '%s' was found in the project '%s' ", name, namespace)
+		log.Debugf("Kogito runtime with name '%s' was found in the project context (namespace) '%s' ", name, namespace)
 		return nil
 	}
 }
@@ -108,9 +108,9 @@ func (r resourceCheckServiceImpl) CheckKogitoRuntimeNotExists(kubeCli *client.Cl
 	if exists, err := isKogitoRuntimeExists(kubeCli, name, namespace); err != nil {
 		return err
 	} else if exists {
-		return fmt.Errorf("Looks like a Kogito Runtime with the name '%s' already exists in this context/namespace. Please try another name ", name)
+		return fmt.Errorf("Looks like a Kogito Runtime with the name '%s' already exists in this project context (namespace). Please try another name ", name)
 	} else {
-		log.Debugf("Custom resource with name '%s' was not found in the project '%s' ", name, namespace)
+		log.Debugf("Custom resource with name '%s' was not found in the project context (namespace) '%s' ", name, namespace)
 		return nil
 	}
 }
@@ -137,9 +137,9 @@ func (r resourceCheckServiceImpl) CheckKogitoBuildExists(kubeCli *client.Client,
 	if exists, err := isKogitoBuildExists(kubeCli, name, namespace); err != nil {
 		return err
 	} else if !exists {
-		return fmt.Errorf("Looks like a Kogito Build with the name '%s' doesn't exist in this project. Please try another name ", name)
+		return fmt.Errorf("Looks like a Kogito Build with the name '%s' doesn't exist in this project context (namespace). Please try another name ", name)
 	} else {
-		log.Debugf("Kogito Build with name '%s' was found in the project '%s' ", name, namespace)
+		log.Debugf("Kogito Build with name '%s' was found in the project context (namespace) '%s' ", name, namespace)
 		return nil
 	}
 }
@@ -150,9 +150,9 @@ func (r resourceCheckServiceImpl) CheckKogitoBuildNotExists(kubeCli *client.Clie
 	if exists, err := isKogitoBuildExists(kubeCli, name, namespace); err != nil {
 		return err
 	} else if exists {
-		return fmt.Errorf("Looks like a Kogito Build with the name '%s' already exists in this context/namespace. Please try another name ", name)
+		return fmt.Errorf("Looks like a Kogito Build with the name '%s' already exists in this project context (namespace). Please try another name ", name)
 	} else {
-		log.Debugf("Kogito Build with name '%s' was not found in the project '%s' ", name, namespace)
+		log.Debugf("Kogito Build with name '%s' was not found in the project context (namespace) '%s' ", name, namespace)
 		return nil
 	}
 }


### PR DESCRIPTION
Signed-off-by: Davide Salerno <dsalerno@redhat.com>

Cherry-pick: https://github.com/kiegroup/kogito-operator/pull/1129

See: https://issues.redhat.com/browse/KOGITO-2787

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've ran `make before-pr` and everything is working accordingly
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>