### PR TITLE
[1.13.x] Prepare branch for productization

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -4,6 +4,8 @@ def changeAuthor = env.ghprbPullAuthorLogin ?: CHANGE_AUTHOR
 def changeBranch = env.ghprbSourceBranch ?: CHANGE_BRANCH
 def changeTarget = env.ghprbTargetBranch ?: CHANGE_TARGET
 
+testsFailed = false
+
 pipeline {
     agent {
         label 'kogito-operator-node'
@@ -71,8 +73,16 @@ pipeline {
                         timeout(time: 90, unit: 'MINUTES')
                     }
                     steps {
-                        // Run just smoke tests to verify basic operator functionality
-                        sh "make run-smoke-tests concurrent=5 ${getBDDParameters()}"
+                        script {
+                            // Unstability if tests failed will be done
+                            try {
+                                // Run just smoke tests to verify basic operator functionality
+                                sh "make run-smoke-tests concurrent=5 ${getBDDParameters()}"
+                            } catch (err) {
+                                testsFailed = true
+                                util.archiveConsoleLog()
+                            }
+                        }
                     }
                     post {
                         always {
@@ -95,6 +105,20 @@ pipeline {
         }
     }
     post {
+        always {
+            script {
+                // Verify here if BDD tests due to test errors or build error
+                if (testsFailed && currentBuild.currentResult == 'SUCCESS') {
+                    error 'There was a test execution failure'
+                }
+            }
+        }
+        unsuccessful {
+            script {
+                def additionalInfo = "You can find test error logs here: ${BUILD_URL}/artifact/test/logs/error/"
+                pullrequest.postComment(util.getMarkdownTestSummary('PR', additionalInfo, "${BUILD_URL}", 'GITHUB'), 'GITHUB_TOKEN')
+            }
+        }
         cleanup {
             script {
                 cleanGoPath()

--- a/.ci/jenkins/Jenkinsfile-rhpam
+++ b/.ci/jenkins/Jenkinsfile-rhpam
@@ -4,6 +4,8 @@ def changeAuthor = env.ghprbPullAuthorLogin ?: CHANGE_AUTHOR
 def changeBranch = env.ghprbSourceBranch ?: CHANGE_BRANCH
 def changeTarget = env.ghprbTargetBranch ?: CHANGE_TARGET
 
+testsFailed = false
+
 pipeline {
     agent {
         label 'kogito-operator-node'
@@ -39,6 +41,9 @@ pipeline {
         }
         stage('Build RHPAM Kogito Operator') {
             steps {
+                // Workaround until Operator PR checks is solved
+                sh "echo '' > content_sets.yaml"
+
                 sh "make -f Makefile.rhpam BUILDER=${CONTAINER_ENGINE}"
             }
         }
@@ -64,8 +69,15 @@ pipeline {
                         timeout(time: 90, unit: 'MINUTES')
                     }
                     steps {
-                        // Run just smoke tests to verify basic operator functionality
-                        sh "make run-smoke-tests tags='@rhpam' concurrent=5 ${getBDDParameters()}"
+                        script {
+                            try {
+                                // Run just smoke tests to verify basic operator functionality
+                                sh "make run-smoke-tests tags='@rhpam' concurrent=5 ${getBDDParameters()}"
+                            } catch (err) {
+                                testsFailed = true
+                                util.archiveConsoleLog()
+                            }
+                        }
                     }
                     post {
                         always {
@@ -81,6 +93,20 @@ pipeline {
         }
     }
     post {
+        always {
+            script {
+                // Verify here if BDD tests due to test errors or build error
+                if (testsFailed && currentBuild.currentResult == 'SUCCESS') {
+                    error 'There was a test execution failure'
+                }
+            }
+        }
+        unsuccessful {
+            script {
+                def additionalInfo = "You can find test error logs here: ${BUILD_URL}/artifact/test/logs/error/"
+                pullrequest.postComment(util.getMarkdownTestSummary('RHPAM PR', additionalInfo, "${BUILD_URL}", 'GITHUB'), 'GITHUB_TOKEN')
+            }
+        }
         cleanup {
             script {
                 cleanGoPath()

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -1,6 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
 helper = null
+testsFailed = false
 
 pipeline {
     agent {
@@ -10,6 +11,7 @@ pipeline {
     // Needed for local build
     tools {
         jdk 'kie-jdk11'
+        maven 'kie-maven-3.8.1'
         go 'golang-1.16'
     }
 
@@ -118,11 +120,25 @@ pipeline {
             steps {
                 sh 'make test'
             }
+            post {
+                unsuccessful {
+                    script {
+                        util.archiveConsoleLog()
+                    }
+                }
+            }
         }
 
         stage('Build Kogito Operator') {
             steps {
                 sh "make BUILDER=${env.CONTAINER_ENGINE}"
+            }
+            post {
+                unsuccessful {
+                    script {
+                        util.archiveConsoleLog()
+                    }
+                }
             }
         }
 
@@ -136,6 +152,11 @@ pipeline {
                         archiveArtifacts artifacts: 'build/_output/bin/kogito', allowEmptyArchive: false
                     }
                 }
+                unsuccessful {
+                    script {
+                        util.archiveConsoleLog()
+                    }
+                }
             }
         }
         stage('Run OLM tests') {
@@ -146,6 +167,13 @@ pipeline {
             }
             steps {
                 sh 'make olm-tests'
+            }
+            post {
+                unsuccessful {
+                    script {
+                        util.archiveConsoleLog()
+                    }
+                }
             }
         }
         stage('Push Operator Image to Openshift Registry') {
@@ -183,14 +211,15 @@ pipeline {
                                 // Use docker because of https://issues.redhat.com/browse/KOGITO-3512
                                 sh "make run-tests timeout=360 load_factor=3 concurrent=3 smoke=${params.SMOKE_TESTS_ONLY} ${getBDDParameters()}"
                             } catch (err) {
-                                unstable('Tests are failing')
+                                testsFailed = true
+                                util.archiveConsoleLog()
                             }
                         }
                     }
                     post {
                         always {
-                            archiveArtifacts artifacts: 'test/logs/**/*.log', allowEmptyArchive: true
-                            junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: true
+                            archiveArtifacts artifacts: 'test/logs/**/*.log', allowEmptyArchive: false
+                            junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: false
                         }
                         cleanup {
                             sh 'cd test && go run scripts/prune_namespaces.go'
@@ -263,6 +292,11 @@ pipeline {
             script {
                 properties.writeToFile(env.PROPERTIES_FILE_NAME)
                 archiveArtifacts(artifacts: env.PROPERTIES_FILE_NAME)
+
+                // Verify here if BDD tests due to test errors or build error
+                if (testsFailed && currentBuild.currentResult == 'SUCCESS') {
+                    error 'There was a test execution failure'
+                }
             }
         }
         unsuccessful {
@@ -279,9 +313,7 @@ pipeline {
 
 void sendNotification() {
     if (params.SEND_NOTIFICATION) {
-        emailext body: "**Deploy job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
-             subject: "[${helper.getBuildBranch()}] Kogito Operator",
-             to: env.KOGITO_CI_EMAIL_TO
+        mailer.sendMarkdownTestSummaryNotification('Deploy', "[${helper.getBuildBranch()}] Kogito Operator", [env.KOGITO_CI_EMAIL_TO], "You can find test error logs here: ${BUILD_URL}/artifact/test/logs/error/")
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.ci/jenkins/Jenkinsfile.examples-images.deploy
+++ b/.ci/jenkins/Jenkinsfile.examples-images.deploy
@@ -1,6 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
 helper = null
+testsFailed = false
 
 pipeline {
     agent {
@@ -10,6 +11,7 @@ pipeline {
     // Needed for local build
     tools {
         jdk 'kie-jdk11'
+        maven 'kie-maven-3.8.1'
         go 'golang-1.16'
     }
 
@@ -72,14 +74,15 @@ pipeline {
                         // Use docker because of https://issues.redhat.com/browse/KOGITO-3512
                         sh "make build-examples-images concurrent=3 smoke=${params.SMOKE_TESTS_ONLY} ${getExamplesBuildParameters(false)}"
                     } catch (err) {
-                        unstable("Error building non-native examples' images. Check the junit results.")
+                        testsFailed = true
+                        util.archiveConsoleLog()
                     }
                 }
             }
             post {
                 always {
-                    archiveArtifacts artifacts: 'test/examples/logs/**/*.log', allowEmptyArchive: true
-                    junit testResults: 'test/examples/logs/**/junit.xml', allowEmptyResults: true
+                    archiveArtifacts artifacts: 'test/examples/logs/**/*.log', allowEmptyArchive: false
+                    junit testResults: 'test/examples/logs/**/junit.xml', allowEmptyResults: false
                 }
             }
         }
@@ -95,7 +98,8 @@ pipeline {
                         // There seems to be a problem with podman executed from the BDD tests ... Using docker instead for now ...
                         sh "make build-examples-images concurrent=1 ${getExamplesBuildParameters(true)}"
                     } catch (err) {
-                        unstable("Error building native examples' images. Check the junit results.")
+                        testsFailed = true
+                        util.archiveConsoleLog()
                     } finally {
                         // moving to another folder to avoid conflicts with junit
                         sh 'cp -r test/examples test/examples-native'
@@ -150,6 +154,11 @@ pipeline {
             script {
                 properties.writeToFile(env.PROPERTIES_FILE_NAME)
                 archiveArtifacts(artifacts: env.PROPERTIES_FILE_NAME)
+
+                // Verify here if BDD tests due to test errors or build error
+                if (testsFailed && currentBuild.currentResult == 'SUCCESS') {
+                    error 'There was a test execution failure'
+                }
             }
         }
         unsuccessful {
@@ -166,9 +175,7 @@ pipeline {
 
 void sendNotification() {
     if (params.SEND_NOTIFICATION) {
-        emailext body: "**Deploy job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
-             subject: "[${helper.getBuildBranch()}] Kogito Examples Images",
-             to: env.KOGITO_CI_EMAIL_TO
+        mailer.sendMarkdownTestSummaryNotification('Deploy', "[${helper.getBuildBranch()}] Kogito Examples Images", [env.KOGITO_CI_EMAIL_TO], "You can find test error logs here: ${BUILD_URL}/artifact/test/examples/logs/error/")
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.ci/jenkins/Jenkinsfile.examples-images.promote
+++ b/.ci/jenkins/Jenkinsfile.examples-images.promote
@@ -116,9 +116,7 @@ pipeline {
 
 void sendNotification() {
     if (params.SEND_NOTIFICATION) {
-        emailext body: "**Promote job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
-             subject: "[${helper.getBuildBranch()}] Kogito Examples Images",
-             to: env.KOGITO_CI_EMAIL_TO
+        mailer.sendMarkdownTestSummaryNotification('Promote', "[${helper.getBuildBranch()}] Kogito Examples Images", [env.KOGITO_CI_EMAIL_TO])
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.ci/jenkins/Jenkinsfile.profiling
+++ b/.ci/jenkins/Jenkinsfile.profiling
@@ -10,6 +10,7 @@ pipeline {
     // Needed for local build
     tools {
         jdk 'kie-jdk11'
+        maven 'kie-maven-3.8.1'
         go 'golang-1.16'
     }
 
@@ -57,6 +58,13 @@ pipeline {
             steps {
                 sh "make profiling BUILDER=${env.CONTAINER_ENGINE}"
             }
+            post {
+                unsuccessful {
+                    script {
+                        util.archiveConsoleLog()
+                    }
+                }
+            }
         }
 
         stage('Build Kogito CLI') {
@@ -67,6 +75,11 @@ pipeline {
                 success {
                     script {
                         archiveArtifacts artifacts: 'build/_output/bin/kogito', allowEmptyArchive: false
+                    }
+                }
+                unsuccessful {
+                    script {
+                        util.archiveConsoleLog()
                     }
                 }
             }
@@ -97,7 +110,11 @@ pipeline {
                     steps {
                         script {
                             // Use docker because of https://issues.redhat.com/browse/KOGITO-3512
-                            sh "make run-tests timeout=360 load_factor=3 concurrent=3 ${getBDDParameters()}"
+                            try {
+                                sh "make run-tests timeout=360 load_factor=3 concurrent=3 ${getBDDParameters()}"
+                            } catch (err) {
+                                util.archiveConsoleLog()
+                            }
                         }
                     }
                     post {
@@ -109,8 +126,8 @@ pipeline {
                                 ./codecov -f test/bdd-cover.out -F bdd -n bdd-tests &> test/logs/bdd-cover-upload.log
                             '''
 
-                            archiveArtifacts artifacts: 'test/logs/**/*.log', allowEmptyArchive: true
-                            junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: true
+                            archiveArtifacts artifacts: 'test/logs/**/*.log', allowEmptyArchive: false
+                            junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: false
                         }
                         cleanup {
                             sh 'cd test && go run scripts/prune_namespaces.go'
@@ -145,9 +162,7 @@ void getLockOpenshiftApi() {
 }
 
 void sendNotification() {
-    emailext body: "**Daily Profiling** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
-             subject: "[${helper.getBuildBranch()}] Kogito Operator",
-             to: env.KOGITO_CI_EMAIL_TO
+    mailer.sendMarkdownTestSummaryNotification('Profiling', "[${helper.getBuildBranch()}] Kogito Operator", [env.KOGITO_CI_EMAIL_TO], "You can find test error logs here: ${BUILD_URL}/artifact/test/logs/error/")
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -174,9 +174,7 @@ pipeline {
 
 void sendNotification() {
     if (params.SEND_NOTIFICATION) {
-        emailext body: "**Promote job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
-             subject: "[${helper.getBuildBranch()}] Kogito Operator",
-             to: env.KOGITO_CI_EMAIL_TO
+        mailer.sendMarkdownTestSummaryNotification('Promote', "[${helper.getBuildBranch()}] Kogito Operator", [env.KOGITO_CI_EMAIL_TO])
     } else {
         echo 'No notification sent per configuration'
     }

--- a/.github/bot-files/reviewers.yml
+++ b/.github/bot-files/reviewers.yml
@@ -8,6 +8,7 @@ review:
     reviewers:
       - ricardozanini
       - spolti
+      - davidesalerno
   - paths:
       - test/**
     reviewers:
@@ -23,3 +24,4 @@ review:
 default:
   - ricardozanini
   - spolti
+  - davidesalerno

--- a/.github/workflows/Kogito-Operator-OLM-tests.yaml
+++ b/.github/workflows/Kogito-Operator-OLM-tests.yaml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod/cache
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-cache-
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-
       - name: Cache the binaries
         uses: actions/cache@v1
         with:
@@ -44,9 +44,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: go.mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-mod-${{ hashFiles('**/go.mod') }}
           restore-keys: |
-            ${{ runner.os }}-go-mod-
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-mod-
       - run: go mod tidy
       - name: Install Cekit and dependencies
         run: |

--- a/.github/workflows/Kogito-Operator-PR-Check.yaml
+++ b/.github/workflows/Kogito-Operator-PR-Check.yaml
@@ -26,16 +26,16 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod/cache
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-cache-
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-
       - name: Cache the binaries
         uses: actions/cache@v1
         with:
           path: ~/go/bin/
-          key: ${{ runner.os }}-go-v1-${{ hashFiles(format('{0}/bin', env.GOPATH)) }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-v1-${{ hashFiles(format('{0}/bin', env.GOPATH)) }}
           restore-keys: |
-            ${{ runner.os }}-go-v1-${{ hashFiles(format('{0}/bin', env.GOPATH)) }}
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-v1-${{ hashFiles(format('{0}/bin', env.GOPATH)) }}
       - name: Install Operator-sdk
         run: ./hack/ci/install-operator-sdk.sh
       - name: Check Vet

--- a/.github/workflows/Kogito-Operator-Unit-tests.yaml
+++ b/.github/workflows/Kogito-Operator-Unit-tests.yaml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod/cache
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-cache-
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-cache-
       - name: Install cover
         run: go get golang.org/x/tools/cmd/cover
       - name: Validate codcov yaml file

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -22,4 +22,4 @@ jobs:
         java-version: 11
       
     - name: Test DSL
-      run: cd .ci/jenkins/dsl && ./test.sh
+      run: cd .ci/jenkins/dsl && ./test.sh 1.13.x


### PR DESCRIPTION
Depends on https://github.com/kiegroup/kogito-pipelines/pull/388

I backported changes from `main` which are useful and removed drools references.

- https://github.com/kiegroup/kogito-pipelines/pull/388
- https://github.com/kiegroup/kogito-pipelines/pull/390
- https://github.com/kiegroup/kogito-runtimes/pull/2028
- https://github.com/kiegroup/optaplanner/pull/1850
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/662
- https://github.com/kiegroup/optaweb-employee-rostering/pull/771
- https://github.com/kiegroup/optaplanner-quickstarts/pull/295
- https://github.com/kiegroup/kogito-apps/pull/1258
- https://github.com/kiegroup/kogito-examples/pull/1144
- https://github.com/kiegroup/kogito-images/pull/1126
- https://github.com/kiegroup/kogito-operator/pull/1139