### PR TITLE
BDD: Setup some debug features

### DIFF
--- a/test/debug_features/README.md
+++ b/test/debug_features/README.md
@@ -1,0 +1,7 @@
+# Debug Features
+
+This folder contains feature files used for local testing / debugging.
+
+They are quite useful when wanting to install a specific environment.
+
+Those should mainly be used with `keep_namespace` property in order to keep the created namespace.

--- a/test/debug_features/install.feature
+++ b/test/debug_features/install.feature
@@ -1,0 +1,38 @@
+Feature: Install feature
+
+  @install-operator
+  Scenario: Install Operator
+    Given Kogito Operator is deployed
+
+  @install-supporting
+  Scenario: Install Supporting service
+    Given Namespace is created
+    And Kogito Operator is deployed
+    And Kafka Operator is deployed
+    And Kafka instance "kogito-kafka" is deployed
+    And Install Kafka Kogito Infra "kafka" targeting service "kogito-kafka" within 5 minutes
+    And Infinispan Operator is deployed
+    And Infinispan instance "kogito-infinispan" is deployed with configuration:
+      | username | developer |
+      | password | mypass    |
+    And Install Infinispan Kogito Infra "infinispan" targeting service "kogito-infinispan" within 5 minutes
+
+    When Install Kogito Data Index with 1 replicas with configuration:
+      | config | database-type | Infinispan               |
+      | config | infra         | infinispan               |
+      | config | infra         | kafka                    |
+
+    Then Kogito Data Index has 1 pods running within 10 minutes
+    And GraphQL request on service "data-index" is successful within 2 minutes with path "graphql" and query:
+    """
+    {
+      ProcessInstances{
+        id
+      }
+    }
+    """
+
+    When Install Kogito Jobs Service with 1 replicas with configuration:
+      | config | database-type | Infinispan |
+      | config | infra         | infinispan |
+    Then Kogito Jobs Service has 1 pods running within 10 minutes

--- a/test/pkg/executor/bdd_executor.go
+++ b/test/pkg/executor/bdd_executor.go
@@ -172,11 +172,11 @@ func initializeTestSuite(ctx *godog.TestSuiteContext) {
 
 	// Final cleanup once test suite finishes
 	ctx.AfterSuite(func() {
-		if config.IsOperatorProfiling() {
-			retrieveProfilingData()
-		}
-
 		if !config.IsKeepNamespace() {
+			if config.IsOperatorProfiling() {
+				retrieveProfilingData()
+			}
+
 			// Delete all operators created by test suite
 			if success := installers.UninstallServicesFromCluster(); !success {
 				framework.GetMainLogger().Warn("Some services weren't uninstalled propertly from cluster, see error logs above")


### PR DESCRIPTION
and profiling is skipped when keep_namespace is active

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [ ] Pull Request contains a description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>