### PR TITLE
[KOGITO-4806] - Track which version of the Operator deployed a Kogito…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,7 @@
 <!-- Keep them in alphabetical order -->
 ## Enhancements
-- [KOGITO-6794](https://issues.redhat.com/browse/KOGITO-6794) - Create configmap for every supporting service route
-- [KOGITO-6812](https://issues.redhat.com/browse/KOGITO-6812) - Kogito operator should support annotation on deployment
-- [KOGITO-6907](https://issues.redhat.com/browse/KOGITO-6907) - Add subscription annotations to and Kogito operators
+- [KOGITO-4806](https://issues.redhat.com/browse/KOGITO-4806) - Track which version of the Operator deployed a KogitoRuntime
+
 ## Bug Fixes
-- [KOGITO-6414](https://issues.redhat.com/browse/KOGITO-6414) - Operator fails reconciliation when specific KafkaTopic exists
-- [KOGITO-2787](https://issues.redhat.com/browse/KOGITO-2787) - Unify namespace/project wording in logs and Kogito CLI
-- [KOGITO-1940](https://issues.redhat.com/browse/KOGITO-1940) - Use services instead routes to inner communication between Kogito services
+
 ## Known Issues

--- a/controllers/app/kogitoruntimedeployment_controller.go
+++ b/controllers/app/kogitoruntimedeployment_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kiegroup/kogito-operator/controllers/common"
 	kogitocli "github.com/kiegroup/kogito-operator/core/client"
 	app2 "github.com/kiegroup/kogito-operator/internal/app"
+	"github.com/kiegroup/kogito-operator/version/app"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -29,6 +30,7 @@ func NewKogitoRuntimeDeploymentReconciler(client *kogitocli.Client, scheme *runt
 	return &common.RuntimeDeploymentReconciler{
 		Client:                client,
 		Scheme:                scheme,
+		Version:               app.Version,
 		RuntimeHandler:        app2.NewKogitoRuntimeHandler,
 		SupportServiceHandler: app2.NewKogitoSupportingServiceHandler,
 	}

--- a/core/deployment/deployment_processor.go
+++ b/core/deployment/deployment_processor.go
@@ -17,6 +17,7 @@ package deployment
 import (
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
 	"github.com/kiegroup/kogito-operator/core/connector"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/manager"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	v1 "k8s.io/api/apps/v1"
@@ -44,12 +45,15 @@ func NewDeploymentProcessor(context operator.Context, deployment *v1.Deployment,
 	}
 }
 
+// Process function is called for every deployment managed or watched by operator
+// e.g. crd or full deployment with the expected label
 func (d *deploymentProcessor) Process() (err error) {
-
+	if err = d.injectKogitoAnnotations(); err != nil {
+		return err
+	}
 	if err = d.injectSupportingServiceEndpointIntoDeployment(); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -67,5 +71,18 @@ func (d *deploymentProcessor) injectSupportingServiceEndpointIntoDeployment() er
 	if err := kubernetes.ResourceC(d.Client).Update(d.deployment); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (d *deploymentProcessor) injectKogitoAnnotations() error {
+	// annotate the given deployment with the operator version
+	if d.deployment.Annotations == nil {
+		d.deployment.Annotations = make(map[string]string)
+	}
+	if d.deployment.Spec.Template.Annotations == nil {
+		d.deployment.Spec.Template.Annotations = make(map[string]string)
+	}
+	d.deployment.Annotations[framework.KogitoOperatorVersionAnnotation] = d.Context.Version
+	d.deployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation] = d.Context.Version
 	return nil
 }

--- a/core/deployment/deployment_processor.go
+++ b/core/deployment/deployment_processor.go
@@ -75,14 +75,18 @@ func (d *deploymentProcessor) injectSupportingServiceEndpointIntoDeployment() er
 }
 
 func (d *deploymentProcessor) injectKogitoAnnotations() error {
-	// annotate the given deployment with the operator version
-	if d.deployment.Annotations == nil {
-		d.deployment.Annotations = make(map[string]string)
+	if len(d.Context.Version) == 0 {
+		d.Log.Warn("Not able to get detect Kogito version, version annotation will not be set", "Version Label", framework.KogitoOperatorVersionAnnotation)
+	} else {
+		// annotate the given deployment with the operator version
+		if d.deployment.Annotations == nil {
+			d.deployment.Annotations = make(map[string]string)
+		}
+		if d.deployment.Spec.Template.Annotations == nil {
+			d.deployment.Spec.Template.Annotations = make(map[string]string)
+		}
+		d.deployment.Annotations[framework.KogitoOperatorVersionAnnotation] = d.Context.Version
+		d.deployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation] = d.Context.Version
 	}
-	if d.deployment.Spec.Template.Annotations == nil {
-		d.deployment.Spec.Template.Annotations = make(map[string]string)
-	}
-	d.deployment.Annotations[framework.KogitoOperatorVersionAnnotation] = d.Context.Version
-	d.deployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation] = d.Context.Version
 	return nil
 }

--- a/core/deployment/deployment_processor_test.go
+++ b/core/deployment/deployment_processor_test.go
@@ -93,6 +93,7 @@ func TestNewDeploymentProcessorTesting(t *testing.T) {
 	v := make(map[string]string)
 	v[framework.KogitoOperatorVersionAnnotation] = "1.0-SNAPSHOT"
 	assert.Equal(t, v, runtimeDeployment.Annotations)
+	assert.Equal(t, v, runtimeDeployment.Spec.Template.Annotations)
 }
 
 func createList(namespace string) *v1beta1.KogitoSupportingServiceList {

--- a/core/deployment/deployment_processor_test.go
+++ b/core/deployment/deployment_processor_test.go
@@ -16,6 +16,7 @@ package deployment
 
 import (
 	"github.com/kiegroup/kogito-operator/apis/app/v1beta1"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/kogitoservice"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/core/test"
@@ -75,19 +76,23 @@ func TestNewDeploymentProcessorTesting(t *testing.T) {
 	cli := test.NewFakeClientBuilder().AddK8sObjects(runtimeDeployment, configmap, supportingServiceList).Build()
 
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
-	RuntimeHandler := app.NewKogitoRuntimeHandler(context)
-	Supportingservicehandler := app.NewKogitoSupportingServiceHandler(context)
+	runtimeHandler := app.NewKogitoRuntimeHandler(context)
+	supportingservicehandler := app.NewKogitoSupportingServiceHandler(context)
 
-	deploymentProcessor := NewDeploymentProcessor(context, runtimeDeployment, RuntimeHandler, Supportingservicehandler)
+	deploymentProcessor := NewDeploymentProcessor(context, runtimeDeployment, runtimeHandler, supportingservicehandler)
 	err := deploymentProcessor.Process()
 
 	assert.NoError(t, err)
 	assert.Equal(t, runtimeDeployment.Spec.Template.Spec.Containers[0].EnvFrom[0].ConfigMapRef.Name, configmap.Name)
 
+	v := make(map[string]string)
+	v[framework.KogitoOperatorVersionAnnotation] = "1.0-SNAPSHOT"
+	assert.Equal(t, v, runtimeDeployment.Annotations)
 }
 
 func createList(namespace string) *v1beta1.KogitoSupportingServiceList {

--- a/core/framework/annotations.go
+++ b/core/framework/annotations.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+const (
+	// KogitoOperatorVersionAnnotation is the default annotation key to identify the version on the deployments managed by operator
+	KogitoOperatorVersionAnnotation = "kogito-operator.kiegroup.org/version"
+)

--- a/core/kogitobuild/build_config.go
+++ b/core/kogitobuild/build_config.go
@@ -56,10 +56,15 @@ func (b *buildConfigHandler) newBuildConfig(build api.KogitoBuildInterface, deco
 		framework.LabelAppKey: app,
 	}
 
+	annotations := map[string]string{
+		framework.KogitoOperatorVersionAnnotation: b.Context.Version,
+	}
+
 	bc := buildv1.BuildConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: build.GetNamespace(),
-			Labels:    labels,
+			Namespace:   build.GetNamespace(),
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: buildv1.BuildConfigSpec{
 			RunPolicy:  buildv1.BuildRunPolicySerial,

--- a/core/kogitoservice/kogito_deployment.go
+++ b/core/kogitoservice/kogito_deployment.go
@@ -59,13 +59,16 @@ func (d *kogitoDeploymentHandler) CreateDeployment(service api.KogitoService, re
 	}
 	labels[framework.LabelAppKey] = service.GetName()
 
+	annotations := make(map[string]string)
+	annotations[framework.KogitoOperatorVersionAnnotation] = d.Version
+
 	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: service.GetName(), Namespace: service.GetNamespace(), Labels: labels},
+		ObjectMeta: metav1.ObjectMeta{Name: service.GetName(), Namespace: service.GetNamespace(), Labels: labels, Annotations: annotations},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: replicas,
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{framework.LabelAppKey: service.GetName()}},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				ObjectMeta: metav1.ObjectMeta{Labels: labels, Annotations: annotations},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{

--- a/core/kogitosupportingservice/dataindex_reconciler_test.go
+++ b/core/kogitosupportingservice/dataindex_reconciler_test.go
@@ -15,11 +15,15 @@
 package kogitosupportingservice
 
 import (
+	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/core/test"
 	"github.com/kiegroup/kogito-operator/internal/app"
 	"github.com/kiegroup/kogito-operator/meta"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -34,9 +38,10 @@ func TestKogitoSupportingServiceDataIndex_Reconcile(t *testing.T) {
 	dataIndex.GetSpec().AddInfra(kogitoInfinispan.GetName())
 	cli := test.NewFakeClientBuilder().AddK8sObjects(dataIndex, kogitoKafka, kogitoInfinispan, kafka).Build()
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
 	r := &dataIndexSupportingServiceResource{
 		supportingServiceContext: supportingServiceContext{
@@ -49,4 +54,10 @@ func TestKogitoSupportingServiceDataIndex_Reconcile(t *testing.T) {
 	}
 	err := r.Reconcile()
 	assert.NoError(t, err)
+
+	dataIndexDeployment := &v1.Deployment{ObjectMeta: v13.ObjectMeta{Name: dataIndex.Name, Namespace: dataIndex.Namespace}}
+	exists, err := kubernetes.ResourceC(cli).Fetch(dataIndexDeployment)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "1.0-SNAPSHOT", dataIndexDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
 }

--- a/core/kogitosupportingservice/dataindex_reconciler_test.go
+++ b/core/kogitosupportingservice/dataindex_reconciler_test.go
@@ -60,4 +60,5 @@ func TestKogitoSupportingServiceDataIndex_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, "1.0-SNAPSHOT", dataIndexDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
+	assert.Equal(t, "1.0-SNAPSHOT", dataIndexDeployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation])
 }

--- a/core/kogitosupportingservice/explainability_reconciler_test.go
+++ b/core/kogitosupportingservice/explainability_reconciler_test.go
@@ -61,4 +61,5 @@ func TestReconcileKogitoSupportingServiceExplainability_Reconcile(t *testing.T) 
 	assert.NoError(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, "1.0-SNAPSHOT", explainabilityDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
+	assert.Equal(t, "1.0-SNAPSHOT", explainabilityDeployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation])
 }

--- a/core/kogitosupportingservice/explainability_reconciler_test.go
+++ b/core/kogitosupportingservice/explainability_reconciler_test.go
@@ -15,11 +15,15 @@
 package kogitosupportingservice
 
 import (
+	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/core/test"
 	"github.com/kiegroup/kogito-operator/internal/app"
 	"github.com/kiegroup/kogito-operator/meta"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -33,9 +37,10 @@ func TestReconcileKogitoSupportingServiceExplainability_Reconcile(t *testing.T) 
 
 	cli := test.NewFakeClientBuilder().AddK8sObjects(kafka, explainabilityService, kogitoKafka).Build()
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
 	r := &explainabilitySupportingServiceResource{
 		supportingServiceContext: supportingServiceContext{
@@ -50,4 +55,10 @@ func TestReconcileKogitoSupportingServiceExplainability_Reconcile(t *testing.T) 
 	// basic checks
 	err := r.Reconcile()
 	assert.NoError(t, err)
+
+	explainabilityDeployment := &v1.Deployment{ObjectMeta: v13.ObjectMeta{Name: explainabilityService.Name, Namespace: explainabilityService.Namespace}}
+	exists, err := kubernetes.ResourceC(cli).Fetch(explainabilityDeployment)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "1.0-SNAPSHOT", explainabilityDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
 }

--- a/core/kogitosupportingservice/jobsservice_reconciler_test.go
+++ b/core/kogitosupportingservice/jobsservice_reconciler_test.go
@@ -64,4 +64,5 @@ func TestReconcileKogitoJobsService_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, "1.0-SNAPSHOT", jobsServiceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
+	assert.Equal(t, "1.0-SNAPSHOT", jobsServiceDeployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation])
 }

--- a/core/kogitosupportingservice/jobsservice_reconciler_test.go
+++ b/core/kogitosupportingservice/jobsservice_reconciler_test.go
@@ -16,11 +16,14 @@ package kogitosupportingservice
 
 import (
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/core/test"
 	"github.com/kiegroup/kogito-operator/internal/app"
 	"github.com/kiegroup/kogito-operator/meta"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -29,9 +32,10 @@ func TestReconcileKogitoJobsService_Reconcile(t *testing.T) {
 	jobsService := test.CreateFakeJobsService(ns)
 	cli := test.NewFakeClientBuilder().AddK8sObjects(jobsService).Build()
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
 	r := &jobsServiceSupportingServiceResource{
 		supportingServiceContext: supportingServiceContext{
@@ -54,4 +58,10 @@ func TestReconcileKogitoJobsService_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, jobsService.GetStatus())
 	assert.Len(t, *jobsService.GetStatus().GetConditions(), 2)
+
+	jobsServiceDeployment := &v1.Deployment{ObjectMeta: v13.ObjectMeta{Name: jobsService.Name, Namespace: jobsService.Namespace}}
+	exists, err := kubernetes.ResourceC(cli).Fetch(jobsServiceDeployment)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "1.0-SNAPSHOT", jobsServiceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
 }

--- a/core/kogitosupportingservice/mgmtconsole_reconciler_test.go
+++ b/core/kogitosupportingservice/mgmtconsole_reconciler_test.go
@@ -16,13 +16,14 @@ package kogitosupportingservice
 
 import (
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/core/test"
 	"github.com/kiegroup/kogito-operator/internal/app"
 	"github.com/kiegroup/kogito-operator/meta"
 	"github.com/stretchr/testify/assert"
-	v12 "k8s.io/api/apps/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/apps/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -31,9 +32,10 @@ func TestReconcileKogitoSupportingServiceMgmtConsole_Reconcile(t *testing.T) {
 	instance := test.CreateFakeMgmtConsole(ns)
 	cli := test.NewFakeClientBuilder().AddK8sObjects(instance).Build()
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
 	r := &mgmtConsoleSupportingServiceResource{
 		supportingServiceContext: supportingServiceContext{
@@ -54,6 +56,12 @@ func TestReconcileKogitoSupportingServiceMgmtConsole_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, instance.GetStatus())
 	assert.Len(t, *instance.GetStatus().GetConditions(), 2)
+
+	instanceDeployment := &v1.Deployment{ObjectMeta: v13.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
+	exists, err := kubernetes.ResourceC(cli).Fetch(instanceDeployment)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
 }
 
 // see: https://issues.redhat.com/browse/KOGITO-2535
@@ -80,8 +88,8 @@ func TestReconcileKogitoSupportingServiceMgmtConsole_CustomImage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check image name inside deployment
-	deployment := v12.Deployment{
-		ObjectMeta: v1.ObjectMeta{Name: instance.Name, Namespace: ns},
+	deployment := v1.Deployment{
+		ObjectMeta: v13.ObjectMeta{Name: instance.Name, Namespace: ns},
 	}
 	exists, err := kubernetes.ResourceC(cli).Fetch(&deployment)
 	assert.True(t, exists)

--- a/core/kogitosupportingservice/mgmtconsole_reconciler_test.go
+++ b/core/kogitosupportingservice/mgmtconsole_reconciler_test.go
@@ -62,6 +62,7 @@ func TestReconcileKogitoSupportingServiceMgmtConsole_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
+	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation])
 }
 
 // see: https://issues.redhat.com/browse/KOGITO-2535

--- a/core/kogitosupportingservice/taskconsole_reconciler_test.go
+++ b/core/kogitosupportingservice/taskconsole_reconciler_test.go
@@ -16,13 +16,14 @@ package kogitosupportingservice
 
 import (
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/core/test"
 	"github.com/kiegroup/kogito-operator/internal/app"
 	"github.com/kiegroup/kogito-operator/meta"
 	"github.com/stretchr/testify/assert"
-	v12 "k8s.io/api/apps/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/apps/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -31,9 +32,10 @@ func TestReconcileKogitoSupportingServiceTaskConsole_Reconcile(t *testing.T) {
 	instance := test.CreateFakeTaskConsole(ns)
 	cli := test.NewFakeClientBuilder().AddK8sObjects(instance).Build()
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
 	r := &taskConsoleSupportingServiceResource{
 		supportingServiceContext: supportingServiceContext{
@@ -54,6 +56,12 @@ func TestReconcileKogitoSupportingServiceTaskConsole_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, instance.GetStatus())
 	assert.Len(t, *instance.GetStatus().GetConditions(), 2)
+
+	instanceDeployment := &v1.Deployment{ObjectMeta: v13.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
+	exists, err := kubernetes.ResourceC(cli).Fetch(instanceDeployment)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
 }
 
 func TestReconcileKogitoSupportingServiceTaskConsole_CustomImage(t *testing.T) {
@@ -78,8 +86,8 @@ func TestReconcileKogitoSupportingServiceTaskConsole_CustomImage(t *testing.T) {
 	err := r.Reconcile()
 	assert.NoError(t, err)
 	// Check image name inside deployment
-	deployment := v12.Deployment{
-		ObjectMeta: v1.ObjectMeta{Name: instance.Name, Namespace: ns},
+	deployment := v1.Deployment{
+		ObjectMeta: v13.ObjectMeta{Name: instance.Name, Namespace: ns},
 	}
 	exists, err := kubernetes.ResourceC(cli).Fetch(&deployment)
 	assert.True(t, exists)

--- a/core/kogitosupportingservice/taskconsole_reconciler_test.go
+++ b/core/kogitosupportingservice/taskconsole_reconciler_test.go
@@ -62,6 +62,7 @@ func TestReconcileKogitoSupportingServiceTaskConsole_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
+	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation])
 }
 
 func TestReconcileKogitoSupportingServiceTaskConsole_CustomImage(t *testing.T) {

--- a/core/kogitosupportingservice/trustyai_reconciler_test.go
+++ b/core/kogitosupportingservice/trustyai_reconciler_test.go
@@ -15,11 +15,15 @@
 package kogitosupportingservice
 
 import (
+	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/core/test"
 	"github.com/kiegroup/kogito-operator/internal/app"
 	"github.com/kiegroup/kogito-operator/meta"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -32,9 +36,10 @@ func TestReconcileKogitoSupportingTrusty_Reconcile(t *testing.T) {
 	instance.GetSpec().AddInfra(kogitoKafka.GetName())
 	cli := test.NewFakeClientBuilder().AddK8sObjects(kafka, instance, kogitoKafka).Build()
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
 	r := &trustyAISupportingServiceResource{
 		supportingServiceContext: supportingServiceContext{
@@ -48,4 +53,10 @@ func TestReconcileKogitoSupportingTrusty_Reconcile(t *testing.T) {
 	// basic checks
 	err := r.Reconcile()
 	assert.NoError(t, err)
+
+	instanceDeployment := &v1.Deployment{ObjectMeta: v13.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
+	exists, err := kubernetes.ResourceC(cli).Fetch(instanceDeployment)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
 }

--- a/core/kogitosupportingservice/trustyai_reconciler_test.go
+++ b/core/kogitosupportingservice/trustyai_reconciler_test.go
@@ -59,4 +59,5 @@ func TestReconcileKogitoSupportingTrusty_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
+	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation])
 }

--- a/core/kogitosupportingservice/trustyui_reconciler_test.go
+++ b/core/kogitosupportingservice/trustyui_reconciler_test.go
@@ -16,13 +16,14 @@ package kogitosupportingservice
 
 import (
 	"github.com/kiegroup/kogito-operator/core/client/kubernetes"
+	"github.com/kiegroup/kogito-operator/core/framework"
 	"github.com/kiegroup/kogito-operator/core/operator"
 	"github.com/kiegroup/kogito-operator/core/test"
 	"github.com/kiegroup/kogito-operator/internal/app"
 	"github.com/kiegroup/kogito-operator/meta"
 	"github.com/stretchr/testify/assert"
-	v12 "k8s.io/api/apps/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/apps/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -31,9 +32,10 @@ func TestReconcileKogitoSupportingServiceTrustyUI_Reconcile(t *testing.T) {
 	instance := test.CreateFakeTrustyUIService(ns)
 	cli := test.NewFakeClientBuilder().AddK8sObjects(instance).Build()
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
 	r := &trustyUISupportingServiceResource{
 		supportingServiceContext: supportingServiceContext{
@@ -55,6 +57,12 @@ func TestReconcileKogitoSupportingServiceTrustyUI_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, instance.GetStatus())
 	assert.Len(t, *instance.GetStatus().GetConditions(), 2)
+
+	instanceDeployment := &v1.Deployment{ObjectMeta: v13.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
+	exists, err := kubernetes.ResourceC(cli).Fetch(instanceDeployment)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
 }
 
 // see: https://issues.redhat.com/browse/KOGITO-2535
@@ -64,9 +72,10 @@ func TestReconcileKogitoTrustyUI_CustomImage(t *testing.T) {
 	instance.GetSpec().SetImage("quay.io/mynamespace/awesome-trusty-ui:0.1.3")
 	cli := test.NewFakeClientBuilder().AddK8sObjects(instance).Build()
 	context := operator.Context{
-		Client: cli,
-		Log:    test.TestLogger,
-		Scheme: meta.GetRegisteredSchema(),
+		Client:  cli,
+		Log:     test.TestLogger,
+		Scheme:  meta.GetRegisteredSchema(),
+		Version: "1.0-SNAPSHOT",
 	}
 	r := &trustyUISupportingServiceResource{
 		supportingServiceContext: supportingServiceContext{
@@ -81,8 +90,8 @@ func TestReconcileKogitoTrustyUI_CustomImage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check image name inside deployment
-	deployment := v12.Deployment{
-		ObjectMeta: v1.ObjectMeta{Name: instance.Name, Namespace: ns},
+	deployment := v1.Deployment{
+		ObjectMeta: v13.ObjectMeta{Name: instance.Name, Namespace: ns},
 	}
 	exists, err := kubernetes.ResourceC(cli).Fetch(&deployment)
 	assert.True(t, exists)

--- a/core/kogitosupportingservice/trustyui_reconciler_test.go
+++ b/core/kogitosupportingservice/trustyui_reconciler_test.go
@@ -63,6 +63,7 @@ func TestReconcileKogitoSupportingServiceTrustyUI_Reconcile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Annotations[framework.KogitoOperatorVersionAnnotation])
+	assert.Equal(t, "1.0-SNAPSHOT", instanceDeployment.Spec.Template.Annotations[framework.KogitoOperatorVersionAnnotation])
 }
 
 // see: https://issues.redhat.com/browse/KOGITO-2535


### PR DESCRIPTION
…Runtime
See: https://issues.redhat.com/browse/KOGITO-4806

Signed-off-by: spolti <fspolti@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've ran `make before-pr` and everything is working accordingly
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ x You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>