### PR TITLE
[1.13.x-blue] KOGITO-7356 Do not use master node in pipelines (#1204)

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ testsFailed = false
 
 pipeline {
     agent {
-        label 'kogito-operator-node'
+        label 'kogito-operator-node && !master'
     }
     tools {
         go 'golang-1.16'

--- a/.ci/jenkins/Jenkinsfile-rhpam
+++ b/.ci/jenkins/Jenkinsfile-rhpam
@@ -8,7 +8,7 @@ testsFailed = false
 
 pipeline {
     agent {
-        label 'kogito-operator-node'
+        label 'kogito-operator-node && !master'
     }
     tools {
         go 'golang-1.16'

--- a/.ci/jenkins/dsl/Jenkinsfile.seed
+++ b/.ci/jenkins/dsl/Jenkinsfile.seed
@@ -1,7 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
 seed_generation = null
-node('master') {
+node('kie-rhel8 && !master') {
     dir("${SEED_REPO}") {
         checkout(githubscm.resolveRepository("${SEED_REPO}", "${SEED_AUTHOR}", "${SEED_BRANCH}", false))
         seed_generation = load "${SEED_SCRIPTS_FILEPATH}"


### PR DESCRIPTION

https://issues.redhat.com/browse/KOGITO-7356

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/485
- https://github.com/kiegroup/kogito-runtimes/pull/2255
- https://github.com/kiegroup/kogito-examples/pull/1286
- https://github.com/kiegroup/kogito-images/pull/1276
- https://github.com/kiegroup/kogito-operator/pull/1205
- https://github.com/kiegroup/optaplanner/pull/2025
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/709
- https://github.com/kiegroup/optaweb-employee-rostering/pull/827
- https://github.com/kiegroup/optaplanner-quickstarts/pull/353