### PR TITLE
KIECLOUD-639 - Remove lookaside cache usage in OSBS

### DIFF
--- a/modules/org.kie.kogito.rhpam.builder.prod/install.sh
+++ b/modules/org.kie.kogito.rhpam.builder.prod/install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+cd $REMOTE_SOURCE_DIR/app
+source $CACHITO_ENV_FILE && go build -a -o rhpam-kogito-operator-manager main.go
+mkdir /workspace && cp $REMOTE_SOURCE_DIR/app/rhpam-kogito-operator-manager /workspace

--- a/modules/org.kie.kogito.rhpam.builder.prod/module.yaml
+++ b/modules/org.kie.kogito.rhpam.builder.prod/module.yaml
@@ -1,5 +1,5 @@
 name: org.kie.kogito.rhpam.builder.prod
-version: "7.11.0"
+version: "7.13.0"
 description: Builds the operator binary (OSBS)
 
 envs:

--- a/modules/org.kie.kogito.rhpam.builder.prod/module.yaml
+++ b/modules/org.kie.kogito.rhpam.builder.prod/module.yaml
@@ -1,0 +1,10 @@
+name: org.kie.kogito.rhpam.builder.prod
+version: "7.11.0"
+description: Builds the operator binary (OSBS)
+
+envs:
+  - name: "GOPRIVATE"
+    value: ""
+
+execute:
+  - script: install.sh

--- a/modules/org.kie.kogito.rhpam.builder/install.sh
+++ b/modules/org.kie.kogito.rhpam.builder/install.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 set -e
 
-if [ -n "$CACHITO_ENV_FILE" ]; then
-  source $CACHITO_ENV_FILE && go build -a -o rhpam-kogito-operator-manager main.go
-  cp $REMOTE_SOURCE_DIR/app/rhpam-kogito-operator-manager /workspace
-else
-  cd /workspace
-  CGO_ENABLED=0 GO111MODULE=on go build -a -o rhpam-kogito-operator-manager main.go;
-fi
+cd /workspace
+CGO_ENABLED=0 GO111MODULE=on go build -a -o rhpam-kogito-operator-manager main.go;

--- a/rhpam-image-prod.yaml
+++ b/rhpam-image-prod.yaml
@@ -8,7 +8,7 @@
     repositories:
       - path: modules
     install:
-      - name: org.kie.kogito.rhpam.builder
+      - name: org.kie.kogito.rhpam.builder.prod
 
   packages:
     content_sets_file: content_sets.yaml


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KIECLOUD-639

This PR introduces an additional module for prod/OSBS builds that strips out the artifacts section to avoid impacting local builds, Cachito is already downloading and unzipping the src into a specific directory. With this section removed CEKit will no longer push main.go to the lookaside cache. 

1.13.x PR : https://github.com/kiegroup/kogito-operator/pull/1214