### PR TITLE
[1.13.x-blue] Correct unit tests

### DIFF
--- a/.github/workflows/Kogito-Operator-OLM-tests.yaml
+++ b/.github/workflows/Kogito-Operator-OLM-tests.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Cekit and dependencies
         run: |
           sudo apt install -y libkrb5-dev
-          sudo pip3 install cekit==3.8.0 odcs docker docker-squash
+          sudo pip3 install cekit==4.1.1 odcs docker==5.0.3 docker-squash
       - name: Build Operator Image
         env:
           BUILDER: docker

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For code contributions, review the following prerequisites:
 - [Golint dependency](https://pkg.go.dev/golang.org/x/lint/golint): go get -u golang.org/x/lint/golint
 - [Golangci-lint](https://golangci-lint.run/usage/install/)
 - [Python 3.x](https://www.python.org/downloads/) v3.x is installed
-- [Cekit](https://cekit.io/) v3.8.0+ is installed
+- [Cekit](https://cekit.io/) 4.1.1+ is installed
 
 ### Building the Kogito Operator
 

--- a/controllers/rhpam/suite_test.go
+++ b/controllers/rhpam/suite_test.go
@@ -50,7 +50,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "rhpam", "bases")},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bamoe", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 


### PR DESCRIPTION
https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/kogito/job/1.13.x-blue/job/nightly/job/kogito-operator-deploy/89/console
```
ok  	github.com/kiegroup/kogito-operator/controllers/app	5.676s	coverage: 100.0% of statements
?   	github.com/kiegroup/kogito-operator/controllers/common	[no test files]
Running Suite: Controller Suite
===============================
Random Seed: [1m1662090718[0m
Will run [1m0[0m of [1m0[0m specs

[1mSTEP[0m: bootstrapping test environment
2022-09-01T23:51:58.812-0400	DEBUG	controller-runtime.test-env	starting control plane	{"api server flags": []}
2022-09-01T23:52:04.014-0400	DEBUG	controller-runtime.test-env	installing CRDs
[91m[1mFailure [5.202 seconds][0m
[91m[1m[BeforeSuite] BeforeSuite [0m
[37m/home/jenkins/workspace/KIE/kogito/1.13.x-blue/nightly/kogito-operator-deploy/controllers/rhpam/suite_test.go:48[0m

  [91mUnexpected error:
      <*fs.PathError | 0xc000446ba0>: {
          Op: "stat",
          Path: "../../config/crd/rhpam/bases",
          Err: <syscall.Errno>0x2,
      }
      stat ../../config/crd/rhpam/bases: no such file or directory
  occurred[0m

  /home/jenkins/workspace/KIE/kogito/1.13.x-blue/nightly/kogito-operator-deploy/controllers/rhpam/suite_test.go:58
[90m------------------------------[0m


[1m[91mRan 0 of 0 Specs in 5.215 seconds[0m
[1m[91mFAIL![0m -- [32m[1m0 Passed[0m | [91m[1m0 Failed[0m | [33m[1m0 Pending[0m | [36m[1m0 Skipped[0m
[38;5;228mYou're using deprecated Ginkgo functionality:[0m
[38;5;228m=============================================[0m
```