### PR TITLE
update go-toolset image to 1.16.12

### DIFF
--- a/rhpam-image-prod.yaml
+++ b/rhpam-image-prod.yaml
@@ -1,7 +1,7 @@
 - schema_version: 1
   name: "operator-builder"
   version: "7.13.1"
-  from: "registry.access.redhat.com/ubi8/go-toolset:1.14.12"
+  from: "registry.access.redhat.com/ubi8/go-toolset:1.16.12"
   description: "Golang builder image for the RHPAM Kogito Operator"
 
   modules:


### PR DESCRIPTION
Kogito Operator doesn't build with go-toolset 1.14.x

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [ ] Pull Request contains a description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>