### PR TITLE
Revert "[1.28.x] Update snapshot version to 1.28.1-snapshot"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.28.1-snapshot
+VERSION ?= 2.0.0-snapshot
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -343,8 +343,8 @@ make run-tests 2>&1 | tee log.out
 
 ```
 $ make
-$ docker tag quay.io/kiegroup/kogito-operator:1.28.1-snapshot quay.io/{USERNAME}/kogito-operator:1.28.1-snapshot
-$ docker push quay.io/{USERNAME}/kogito-operator:1.28.1-snapshot
+$ docker tag quay.io/kiegroup/kogito-operator:2.0.0-snapshot quay.io/{USERNAME}/kogito-operator:2.0.0-snapshot
+$ docker push quay.io/{USERNAME}/kogito-operator:2.0.0-snapshot
 $ make run-tests operator_image=quay.io/{USERNAME}/kogito-operator
 ```
 

--- a/bundle/app/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/bundle/app/manifests/kogito-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/kiegroup/kogito-operator:1.28.1-snapshot
+    containerImage: quay.io/kiegroup/kogito-operator:2.0.0-snapshot
     createdAt: "2019-08-22T13:12:22Z"
     description: Kogito Operator for deployment and management of Kogito services.
     operators.operatorframework.io/builder: operator-sdk-v1.21.0
@@ -66,7 +66,7 @@ metadata:
     tectonic-visibility: ocs
   labels:
     operator-kogitocloud: "true"
-  name: kogito-operator.v1.28.1-snapshot
+  name: kogito-operator.v2.0.0-snapshot
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -925,7 +925,7 @@ spec:
                   value: kogito-runtime-native
                 - name: IMAGE_REGISTRY
                   value: quay.io/kiegroup
-                image: quay.io/kiegroup/kogito-operator:1.28.1-snapshot
+                image: quay.io/kiegroup/kogito-operator:2.0.0-snapshot
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1006,7 +1006,7 @@ spec:
   - automation
   labels:
     alm-owner-kogito: kogito-operator
-    operated-by: kogito-operator.1.28.1-snapshot
+    operated-by: kogito-operator.2.0.0-snapshot
   links:
   - name: Product Page
     url: https://kogito.kie.org/
@@ -1020,5 +1020,5 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  replaces: kogito-operator.v1.27.0
-  version: 1.28.1-snapshot
+  replaces: kogito-operator.v1.9.0
+  version: 2.0.0-snapshot

--- a/config/manager/app/kustomization.yaml
+++ b/config/manager/app/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kiegroup/kogito-operator
-  newTag: 1.28.1-snapshot
+  newTag: 2.0.0-snapshot

--- a/config/manifests/app/bases/kogito-operator.clusterserviceversion.yaml
+++ b/config/manifests/app/bases/kogito-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/kiegroup/kogito-operator:1.28.1-snapshot
+    containerImage: quay.io/kiegroup/kogito-operator:2.0.0-snapshot
     createdAt: "2019-08-22T13:12:22Z"
     description: Kogito Operator for deployment and management of Kogito services.
     repository: https://github.com/kiegroup/kogito-operator
@@ -535,7 +535,7 @@ spec:
   - automation
   labels:
     alm-owner-kogito: kogito-operator
-    operated-by: kogito-operator.1.28.1-snapshot
+    operated-by: kogito-operator.2.0.0-snapshot
   links:
   - name: Product Page
     url: https://kogito.kie.org/
@@ -549,5 +549,5 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  replaces: kogito-operator.v1.27.0
-  version: 1.28.1-snapshot
+  replaces: kogito-operator.v1.9.0
+  version: 2.0.0-snapshot

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -2669,7 +2669,7 @@ spec:
           value: kogito-runtime-native
         - name: IMAGE_REGISTRY
           value: quay.io/kiegroup
-        image: quay.io/kiegroup/kogito-operator:1.28.1-snapshot
+        image: quay.io/kiegroup/kogito-operator:2.0.0-snapshot
         livenessProbe:
           httpGet:
             path: /healthz

--- a/profiling/kogito-operator-profiling.yaml
+++ b/profiling/kogito-operator-profiling.yaml
@@ -2670,7 +2670,7 @@ spec:
           value: kogito-runtime-native
         - name: IMAGE_REGISTRY
           value: quay.io/kiegroup
-        image: quay.io/kiegroup/kogito-operator-profiling:1.28.1-snapshot
+        image: quay.io/kiegroup/kogito-operator-profiling:2.0.0-snapshot
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test/.default_config
+++ b/test/.default_config
@@ -1,10 +1,10 @@
-tests.build_builder_image_tag=quay.io/kiegroup/kogito-s2i-builder-nightly:1.28
-tests.build_runtime_jvm_image_tag=quay.io/kiegroup/kogito-runtime-jvm-nightly:1.28
-tests.build_runtime_native_image_tag=quay.io/kiegroup/kogito-runtime-native-nightly:1.28
+tests.build_builder_image_tag=quay.io/kiegroup/kogito-s2i-builder-nightly:latest
+tests.build_runtime_jvm_image_tag=quay.io/kiegroup/kogito-runtime-jvm-nightly:latest
+tests.build_runtime_native_image_tag=quay.io/kiegroup/kogito-runtime-native-nightly:latest
 tests.services_image_name_suffix=nightly
-tests.services_image_version=1.28
+tests.services_image_version=latest
 tests.runtime_application_image_registry=quay.io/kiegroup
 tests.runtime_application_image_name_prefix=examples
 tests.runtime_application_image_name_suffix=nightly
-tests.runtime_application_image_version=1.28
-tests.examples_ref=nightly-1.28.x
+tests.runtime_application_image_version=latest
+tests.examples_ref=nightly-main

--- a/version/app/version.go
+++ b/version/app/version.go
@@ -16,5 +16,5 @@ package app
 
 var (
 	// Version of Kogito Operator
-	Version = "1.28.1-snapshot"
+	Version = "2.0.0-snapshot"
 )


### PR DESCRIPTION
Reverts kiegroup/kogito-operator#1292

We need first to have https://github.com/kiegroup/kogito-operator/pull/1290 merged